### PR TITLE
Fix relative OG image URLs in metadata extraction

### DIFF
--- a/src/lib/services/__tests__/metadata.test.ts
+++ b/src/lib/services/__tests__/metadata.test.ts
@@ -18,6 +18,14 @@ describe("extractMetadata", () => {
     expect(result.ogImage).toBeNull();
   });
 
+  it("resolves relative OG image paths against the page URL", async () => {
+    const result = await extractMetadata("https://example.com/relative-og-image");
+
+    expect(result.title).toBe("Tool With Relative OG Image");
+    expect(result.description).toBeNull();
+    expect(result.ogImage).toBe("https://example.com/social-media-tile.png");
+  });
+
   it("handles pages with minimal metadata", async () => {
     const result = await extractMetadata("https://example.com/minimal");
 

--- a/src/lib/services/metadata.ts
+++ b/src/lib/services/metadata.ts
@@ -10,6 +10,21 @@ export interface MetadataResult {
   error?: string;
 }
 
+function resolveMetadataUrl(
+  candidateUrl: string | undefined,
+  pageUrl: string,
+): string | null {
+  if (!candidateUrl) {
+    return null;
+  }
+
+  try {
+    return new URL(candidateUrl, pageUrl).href;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Extracts metadata (title, description, OG image) from a URL
  * @param url - URL to fetch and extract metadata from
@@ -47,7 +62,10 @@ export async function extractMetadata(url: string): Promise<MetadataResult> {
     const description = ogDescription || metaDescription || null;
 
     // Extract OG image
-    const ogImage = $('meta[property="og:image"]').attr("content") || null;
+    const ogImage = resolveMetadataUrl(
+      $('meta[property="og:image"]').attr("content"),
+      url,
+    );
 
     return { title, description, ogImage };
   } catch (error) {

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -51,6 +51,23 @@ export const handlers = [
     `);
   }),
 
+  // Mock external page with relative OG image path
+  http.get("https://example.com/relative-og-image", () => {
+    return HttpResponse.html(`
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Tool With Relative OG Image</title>
+          <meta
+            property="og:image"
+            content="/social-media-tile.png"
+          />
+        </head>
+        <body><h1>Tool</h1></body>
+      </html>
+    `);
+  }),
+
   // Mock external page with minimal metadata
   http.get("https://example.com/minimal", () => {
     return HttpResponse.html(`


### PR DESCRIPTION
## Summary
- resolve `og:image` values against the source page URL before storing them
- preserve existing behavior for absolute image URLs and invalid or missing values
- add a regression test and mock page coverage for relative image paths

## Testing
- `pnpm run typecheck`
- `pnpm test -- src/lib/services/__tests__/metadata.test.ts`