### PR TITLE
Optimize homepage tag filter loading

### DIFF
--- a/netlify/functions/__tests__/get-tags.test.ts
+++ b/netlify/functions/__tests__/get-tags.test.ts
@@ -40,7 +40,8 @@ function createMockDb() {
     leftJoin: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
     groupBy: vi.fn().mockReturnThis(),
-    orderBy: vi.fn().mockResolvedValue([]),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue([]),
   };
 }
 
@@ -97,5 +98,30 @@ describe("get-tags", () => {
       { id: "t1", name: "react", usageCount: 2 },
       { id: "t2", name: "typescript", usageCount: 1 },
     ]);
+  });
+
+  it("applies a limit when requested", async () => {
+    mockDb.limit.mockResolvedValueOnce([
+      { id: "t1", name: "react", usageCount: 2 },
+    ]);
+
+    const req = new Request("https://test.com/api/tags?limit=10");
+    const res = await getTags(req, mockContext);
+
+    expect(res.status).toBe(200);
+    expect(mockDb.limit).toHaveBeenCalledWith(10);
+
+    const body = (await res.json()) as SuccessResponse<TagsResponseData>;
+    expect(body.data.tags).toEqual([
+      { id: "t1", name: "react", usageCount: 2 },
+    ]);
+  });
+
+  it("returns 400 for an invalid limit", async () => {
+    const req = new Request("https://test.com/api/tags?limit=0");
+    const res = await getTags(req, mockContext);
+
+    expect(res.status).toBe(400);
+    expect(mockDb.limit).not.toHaveBeenCalled();
   });
 });

--- a/netlify/functions/get-tags.mts
+++ b/netlify/functions/get-tags.mts
@@ -7,6 +7,7 @@ import {
   bookmarkTagsTable,
   bookmarksTable,
   ok,
+  badRequest,
   methodNotAllowed,
   assertRequiredEnv,
   handleMissingEnvironmentError,
@@ -15,6 +16,8 @@ import {
   flushSentry,
   serverError,
 } from "./lib";
+
+const MAX_LIMIT = 100;
 
 export default async (req: Request, context: Context) => {
   const handlerStart = Date.now();
@@ -30,11 +33,25 @@ export default async (req: Request, context: Context) => {
     return handleMissingEnvironmentError(error, "get-tags");
   }
 
+  const url = new URL(req.url);
+  const limitParam = url.searchParams.get("limit");
+  let limit: number | undefined;
+
+  if (limitParam) {
+    const parsedLimit = parseInt(limitParam, 10);
+
+    if (isNaN(parsedLimit) || parsedLimit < 1) {
+      return badRequest("limit must be a positive integer");
+    }
+
+    limit = Math.min(parsedLimit, MAX_LIMIT);
+  }
+
   try {
     const db = getDb();
     const dbStart = Date.now();
 
-    const rows = await db
+    const tagsQuery = db
       .select({
         id: tagsTable.id,
         name: tagsTable.name,
@@ -50,12 +67,17 @@ export default async (req: Request, context: Context) => {
       .groupBy(tagsTable.id, tagsTable.name)
       .orderBy(desc(countDistinct(bookmarkTagsTable.bookmarkId)), tagsTable.name);
 
+    const rows = limit === undefined
+      ? await tagsQuery
+      : await tagsQuery.limit(limit);
+
     const dbDurationMs = Date.now() - dbStart;
     const handlerDurationMs = Date.now() - handlerStart;
 
     console.info("[perf] get-tags", {
       requestId: context.requestId,
       queryMode: "tags",
+      limit,
       rowCount: rows.length,
       dbDurationMs,
       mapDurationMs: 0,
@@ -70,7 +92,7 @@ export default async (req: Request, context: Context) => {
       })),
     });
   } catch (error) {
-    captureError(error, { requestId: context.requestId });
+    captureError(error, { requestId: context.requestId, limit });
     await flushSentry();
     return serverError("An error occurred while fetching tags");
   }

--- a/src/api/__tests__/bookmarks.test.ts
+++ b/src/api/__tests__/bookmarks.test.ts
@@ -114,14 +114,18 @@ function createSearchBookmarksHandler() {
 }
 
 function createGetTagsHandler() {
-  return http.get(`${API_BASE}/api/tags`, () => {
+  return http.get(`${API_BASE}/api/tags`, ({ request }) => {
+    const url = new URL(request.url);
+    const limit = url.searchParams.get("limit");
+    const tags = [
+      { id: "t1", name: "javascript", usageCount: 2 },
+      { id: "t2", name: "react", usageCount: 1 },
+    ];
+
     return HttpResponse.json({
       success: true,
       data: {
-        tags: [
-          { id: "t1", name: "javascript", usageCount: 2 },
-          { id: "t2", name: "react", usageCount: 1 },
-        ],
+        tags: limit ? tags.slice(0, parseInt(limit, 10)) : tags,
       },
     });
   });
@@ -278,6 +282,18 @@ describe("getTags", () => {
       name: "javascript",
       usageCount: 2,
     });
+  });
+
+  it("passes limit through to the tags endpoint", async () => {
+    const result = await getTags({ limit: 1 });
+
+    expect(result.tags).toEqual([
+      {
+        id: "t1",
+        name: "javascript",
+        usageCount: 2,
+      },
+    ]);
   });
 });
 

--- a/src/api/bookmarks.ts
+++ b/src/api/bookmarks.ts
@@ -113,6 +113,10 @@ interface RequestOptions {
   signal?: AbortSignal;
 }
 
+export interface GetTagsParams {
+  limit?: number;
+}
+
 // ============================================================================
 // Error Class
 // ============================================================================
@@ -285,8 +289,19 @@ export async function searchBookmarks(
  * @returns Available tags with optional usage counts
  * @throws BookmarkApiError on API errors
  */
-export async function getTags(): Promise<TagsResponse> {
-  return fetchValidatedResponse("/api/tags", tagsResponseSchema);
+export async function getTags(
+  params: GetTagsParams = {},
+): Promise<TagsResponse> {
+  const searchParams = new URLSearchParams();
+
+  if (params.limit !== undefined) {
+    searchParams.set("limit", String(params.limit));
+  }
+
+  const queryString = searchParams.toString();
+  const path = `/api/tags${queryString ? `?${queryString}` : ""}`;
+
+  return fetchValidatedResponse(path, tagsResponseSchema);
 }
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,5 +13,6 @@ export {
   type PaginationInfo,
   type ApiError,
   type GetBookmarksParams,
+  type GetTagsParams,
   type SearchBookmarksParams,
 } from "./bookmarks";

--- a/src/hooks/__tests__/useTags.test.tsx
+++ b/src/hooks/__tests__/useTags.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import { server } from "../../test/mocks/server";
+import { useTags } from "../useTags";
+
+const mockTags = [
+  { id: "t1", name: "javascript", usageCount: 3 },
+  { id: "t2", name: "react", usageCount: 2 },
+];
+
+const requestSpy = vi.fn();
+
+beforeEach(() => {
+  requestSpy.mockReset();
+  server.use(
+    http.get("/api/tags", ({ request }) => {
+      const url = new URL(request.url);
+      requestSpy(url.searchParams.get("limit"));
+
+      return HttpResponse.json({
+        success: true,
+        data: {
+          tags: mockTags,
+        },
+      });
+    }),
+  );
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+describe("useTags", () => {
+  it("does not fetch until enabled", () => {
+    const { result } = renderHook(() => useTags({ enabled: false, limit: 10 }));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.tags).toEqual([]);
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches tags when enabled and forwards limit", async () => {
+    const { result } = renderHook(() => useTags({ enabled: true, limit: 10 }));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.tags).toEqual(mockTags);
+    expect(requestSpy).toHaveBeenCalledWith("10");
+  });
+});

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "react";
 
-import { getTags, type BookmarkApiError, type Tag } from "../api";
+import {
+  getTags,
+  type BookmarkApiError,
+  type GetTagsParams,
+  type Tag,
+} from "../api";
 
 interface UseTagsState {
   tags: Tag[];
@@ -8,10 +13,15 @@ interface UseTagsState {
   error: BookmarkApiError | null;
 }
 
+interface UseTagsOptions extends GetTagsParams {
+  enabled?: boolean;
+}
+
 /**
  * Fetches homepage tags independently from the bookmark listing payload.
  */
-export function useTags(): UseTagsState {
+export function useTags(options: UseTagsOptions = {}): UseTagsState {
+  const { enabled = true, limit } = options;
   const [state, setState] = useState<UseTagsState>({
     tags: [],
     isLoading: false,
@@ -19,6 +29,10 @@ export function useTags(): UseTagsState {
   });
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     let isActive = true;
     const startedAt =
       typeof performance !== "undefined" && typeof performance.now === "function"
@@ -27,7 +41,7 @@ export function useTags(): UseTagsState {
 
     setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
-    getTags()
+    getTags({ limit })
       .then((data) => {
         if (!isActive) {
           return;
@@ -65,7 +79,7 @@ export function useTags(): UseTagsState {
     return () => {
       isActive = false;
     };
-  }, []);
+  }, [enabled, limit]);
 
   return state;
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,6 +10,29 @@ import type { Bookmark } from "../api";
 
 import "./HomePage.css";
 
+const HOMEPAGE_TAG_LIMIT = 10;
+const IDLE_TAG_LOAD_FALLBACK_MS = 1;
+
+function scheduleAfterMainUiReady(onReady: () => void): () => void {
+  if (typeof globalThis.requestIdleCallback === "function") {
+    const idleCallbackId = globalThis.requestIdleCallback(() => {
+      onReady();
+    });
+
+    return () => {
+      globalThis.cancelIdleCallback?.(idleCallbackId);
+    };
+  }
+
+  const timeoutId = globalThis.setTimeout(() => {
+    onReady();
+  }, IDLE_TAG_LOAD_FALLBACK_MS);
+
+  return () => {
+    globalThis.clearTimeout(timeoutId);
+  };
+}
+
 /**
  * Transforms bookmarks to ToolCard props format.
  */
@@ -58,6 +81,7 @@ export function HomePage() {
   const [searchQuery, setSearchQuery] = useState(
     () => searchParams.get("q") ?? ""
   );
+  const [shouldLoadTags, setShouldLoadTags] = useState(false);
   const [selectedTagNames, setSelectedTagNames] = useState<string[]>(() => {
     const tagsParam = searchParams.get("tags");
     return tagsParam ? tagsParam.split(",").filter(Boolean) : [];
@@ -81,7 +105,7 @@ export function HomePage() {
   const {
     tags: homepageTags,
     error: tagsError,
-  } = useTags();
+  } = useTags({ enabled: shouldLoadTags, limit: HOMEPAGE_TAG_LIMIT });
 
   // Search hook for filtered results
   const {
@@ -154,6 +178,12 @@ export function HomePage() {
   /**
    * Trigger search from URL params on initial load.
    */
+  useEffect(() => {
+    return scheduleAfterMainUiReady(() => {
+      setShouldLoadTags(true);
+    });
+  }, []);
+
   useEffect(() => {
     if (initialSearchTriggered.current) {
       return;

--- a/src/pages/__tests__/HomePage.test.tsx
+++ b/src/pages/__tests__/HomePage.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HomePage } from "../HomePage";
+import { useBookmarks, useSearch, useTags } from "../../hooks";
+
+vi.mock("../../hooks", () => ({
+  useBookmarks: vi.fn(),
+  useSearch: vi.fn(),
+  useTags: vi.fn(),
+}));
+
+function LocationDisplay() {
+  const location = useLocation();
+
+  return <div data-testid="location">{location.search}</div>;
+}
+
+const mockBookmark = {
+  id: "b1",
+  title: "Tool One",
+  description: "A great tool",
+  imageUrl: null,
+  submitterName: null,
+  submitterGithubUrl: null,
+  url: "https://example.com/tool-1",
+  createdAt: "2024-01-15T10:00:00Z",
+  tags: [{ id: "t1", name: "javascript" }],
+};
+
+describe("HomePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useBookmarks).mockReturnValue({
+      bookmarks: [mockBookmark],
+      pagination: { total: null, limit: 20, offset: 0, hasMore: false },
+      isLoading: false,
+      error: null,
+      fetch: vi.fn(),
+      loadMore: vi.fn(),
+      reset: vi.fn(),
+    });
+
+    vi.mocked(useSearch).mockReturnValue({
+      results: [],
+      pagination: null,
+      isLoading: false,
+      error: null,
+      search: vi.fn(),
+      loadMore: vi.fn(),
+      reset: vi.fn(),
+    });
+  });
+
+  it("defers tag loading until the idle callback runs", () => {
+    let idleCallback: IdleRequestCallback | undefined;
+    const requestIdleCallbackMock = vi.fn((callback: IdleRequestCallback) => {
+      idleCallback = callback;
+      return 1;
+    });
+
+    vi.stubGlobal("requestIdleCallback", requestIdleCallbackMock);
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+
+    vi.mocked(useTags).mockImplementation(({ enabled = true, limit } = {}) => {
+      if (!enabled) {
+        return { tags: [], isLoading: false, error: null };
+      }
+
+      expect(limit).toBe(10);
+
+      return {
+        tags: [{ id: "t1", name: "javascript", usageCount: 3 }],
+        isLoading: false,
+        error: null,
+      };
+    });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "javascript" })).not.toBeInTheDocument();
+    expect(requestIdleCallbackMock).toHaveBeenCalledOnce();
+
+    act(() => {
+      idleCallback?.({
+        didTimeout: false,
+        timeRemaining: () => 50,
+      });
+    });
+
+    expect(screen.getByRole("button", { name: "javascript" })).toBeInTheDocument();
+    expect(vi.mocked(useTags)).toHaveBeenLastCalledWith({
+      enabled: true,
+      limit: 10,
+    });
+  });
+
+  it("loads tags after the timeout fallback and keeps tag filtering wired up", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestIdleCallback", undefined);
+    vi.stubGlobal("cancelIdleCallback", undefined);
+
+    const searchMock = vi.fn();
+    vi.mocked(useSearch).mockReturnValue({
+      results: [],
+      pagination: null,
+      isLoading: false,
+      error: null,
+      search: searchMock,
+      loadMore: vi.fn(),
+      reset: vi.fn(),
+    });
+
+    vi.mocked(useTags).mockImplementation(({ enabled = true } = {}) => ({
+      tags: enabled
+        ? [{ id: "t1", name: "javascript", usageCount: 3 }]
+        : [],
+      isLoading: false,
+      error: null,
+    }));
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "javascript" })).not.toBeInTheDocument();
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    await user.click(screen.getByRole("button", { name: "javascript" }));
+
+    expect(searchMock).toHaveBeenCalledWith(
+      { q: undefined, tags: ["javascript"] },
+      { immediate: true },
+    );
+    expect(screen.getByTestId("location")).toHaveTextContent("?tags=javascript&mode=filter");
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- limit the homepage tag API request to the top 10 tags
- defer tag fetching until after the main homepage UI mounts and the browser is idle
- keep tag filtering behavior intact once the deferred tag UI loads

## Testing
- `pnpm test`
- `npm run typecheck`