### PR TITLE
Support article public listing kinds

### DIFF
--- a/migrations/postgres/0005_public_listing_content_kind.sql
+++ b/migrations/postgres/0005_public_listing_content_kind.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public_listings" ADD COLUMN "content_kind" text DEFAULT 'resource' NOT NULL;--> statement-breakpoint
+ALTER TABLE "public_listings" ADD CONSTRAINT "public_listings_content_kind_check" CHECK ("public_listings"."content_kind" in ('article', 'resource'));

--- a/migrations/postgres/meta/0005_snapshot.json
+++ b/migrations/postgres/meta/0005_snapshot.json
@@ -1,0 +1,1361 @@
+{
+  "id": "3f8f6ac3-7bfe-43ad-8e88-78ddb20d1c04",
+  "prevId": "7273dc61-0f03-4950-bbf3-400e26d2d630",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_override": {
+          "name": "title_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_override": {
+          "name": "description_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookmarks_user_created": {
+          "name": "idx_bookmarks_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_parent": {
+          "name": "idx_bookmarks_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_resource": {
+          "name": "idx_bookmarks_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_user_resource": {
+          "name": "unique_user_resource",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_resource_id_resources_id_fk": {
+          "name": "bookmarks_resource_id_resources_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_parent_id_bookmarks_id_fk": {
+          "name": "bookmarks_parent_id_bookmarks_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_listings": {
+      "name": "public_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_by_bookmark_id": {
+          "name": "submitted_by_bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_github_url": {
+          "name": "submitter_github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resource'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_public_listings_status": {
+          "name": "idx_public_listings_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_listings_tags": {
+          "name": "idx_public_listings_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_listings_search": {
+          "name": "idx_public_listings_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_listings_resource": {
+          "name": "idx_public_listings_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_public_listing_resource": {
+          "name": "unique_public_listing_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_listings_resource_id_resources_id_fk": {
+          "name": "public_listings_resource_id_resources_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_listings_submitted_by_user_id_users_id_fk": {
+          "name": "public_listings_submitted_by_user_id_users_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_listings_submitted_by_bookmark_id_bookmarks_id_fk": {
+          "name": "public_listings_submitted_by_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["submitted_by_bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "public_listings_reviewed_by_users_id_fk": {
+          "name": "public_listings_reviewed_by_users_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "public_listings_content_kind_check": {
+          "name": "public_listings_content_kind_check",
+          "value": "\"public_listings\".\"content_kind\" in ('article', 'resource')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.public_stack_items": {
+      "name": "public_stack_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public_stack_id": {
+          "name": "public_stack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookmark_id": {
+          "name": "bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_public_listing_id": {
+          "name": "source_public_listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_public_stack_item_bookmark": {
+          "name": "unique_public_stack_item_bookmark",
+          "columns": [
+            {
+              "expression": "bookmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_public_stack_resource": {
+          "name": "unique_public_stack_resource",
+          "columns": [
+            {
+              "expression": "public_stack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_status": {
+          "name": "idx_public_stack_items_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_stack": {
+          "name": "idx_public_stack_items_stack",
+          "columns": [
+            {
+              "expression": "public_stack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_tags": {
+          "name": "idx_public_stack_items_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stack_items_search": {
+          "name": "idx_public_stack_items_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stack_items_resource": {
+          "name": "idx_public_stack_items_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_stack_items_public_stack_id_public_stacks_id_fk": {
+          "name": "public_stack_items_public_stack_id_public_stacks_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "public_stacks",
+          "columnsFrom": ["public_stack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_bookmark_id_bookmarks_id_fk": {
+          "name": "public_stack_items_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_resource_id_resources_id_fk": {
+          "name": "public_stack_items_resource_id_resources_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_source_public_listing_id_public_listings_id_fk": {
+          "name": "public_stack_items_source_public_listing_id_public_listings_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "public_listings",
+          "columnsFrom": ["source_public_listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_reviewed_by_users_id_fk": {
+          "name": "public_stack_items_reviewed_by_users_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_stacks": {
+      "name": "public_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root_bookmark_id": {
+          "name": "root_bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_public_stack_root": {
+          "name": "unique_public_stack_root",
+          "columns": [
+            {
+              "expression": "root_bookmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_status": {
+          "name": "idx_public_stacks_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_tags": {
+          "name": "idx_public_stacks_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stacks_search": {
+          "name": "idx_public_stacks_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stacks_owner": {
+          "name": "idx_public_stacks_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_resource": {
+          "name": "idx_public_stacks_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_stacks_root_bookmark_id_bookmarks_id_fk": {
+          "name": "public_stacks_root_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["root_bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_resource_id_resources_id_fk": {
+          "name": "public_stacks_resource_id_resources_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_owner_user_id_users_id_fk": {
+          "name": "public_stacks_owner_user_id_users_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_reviewed_by_users_id_fk": {
+          "name": "public_stacks_reviewed_by_users_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resources_normalized_url_unique": {
+          "name": "resources_normalized_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["normalized_url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_listings": {
+      "name": "tool_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_source": {
+          "name": "image_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_github_url": {
+          "name": "submitter_github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_listings_status_created": {
+          "name": "idx_tool_listings_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_tool_listing_resource": {
+          "name": "unique_tool_listing_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tool_listings_resource_id_resources_id_fk": {
+          "name": "tool_listings_resource_id_resources_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "highlight_color": {
+          "name": "highlight_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_role": {
+          "name": "unique_user_role",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/postgres/meta/_journal.json
+++ b/migrations/postgres/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1783176429994,
       "tag": "0004_public_listing_attribution",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1783178299192,
+      "tag": "0005_public_listing_content_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/netlify/functions/__tests__/get-resources.test.ts
+++ b/netlify/functions/__tests__/get-resources.test.ts
@@ -9,7 +9,7 @@ interface PublicResource {
   description: string | null;
   tags: { id: string; name: string }[];
   createdAt: string;
-  kind: "resource" | "stack";
+  kind: "article" | "resource" | "stack";
   children?: Array<{
     id: string;
     url: string;
@@ -108,12 +108,12 @@ describe("get-resources", () => {
           },
           {
             id: "listing-1",
-            url: "https://example.com/tool",
-            title: "Tool",
+            url: "https://example.com/article",
+            title: "Article",
             description: null,
             tags: ["design"],
             created_at: "2024-01-02T00:00:00.000Z",
-            kind: "resource",
+            kind: "article",
           },
         ],
       })
@@ -159,12 +159,12 @@ describe("get-resources", () => {
       },
       {
         id: "listing-1",
-        url: "https://example.com/tool",
-        title: "Tool",
+        url: "https://example.com/article",
+        title: "Article",
         description: null,
         tags: [{ id: "design", name: "design" }],
         createdAt: "2024-01-02T00:00:00.000Z",
-        kind: "resource",
+        kind: "article",
       },
     ]);
     expect(body.data.pagination).toEqual({

--- a/netlify/functions/__tests__/search-resources.test.ts
+++ b/netlify/functions/__tests__/search-resources.test.ts
@@ -9,7 +9,7 @@ interface PublicResource {
   description: string | null;
   tags: { id: string; name: string }[];
   createdAt: string;
-  kind: "resource" | "stack";
+  kind: "article" | "resource" | "stack";
   children?: Array<{
     id: string;
     url: string;
@@ -216,6 +216,43 @@ describe("search-resources", () => {
     expect(body.data.resources).toEqual([]);
     expect(body.data.pagination.total).toBe(0);
     expect(body.data.pagination.hasMore).toBe(false);
+    expect(mockDb.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves article kinds for matching public listings", async () => {
+    mockDb.execute
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "article-1",
+            url: "https://example.com/article",
+            title: "Article",
+            description: "Useful reading",
+            tags: ["reading"],
+            created_at: "2024-01-04T00:00:00.000Z",
+            kind: "article",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ total: 1 }] });
+
+    const req = new Request("https://test.com/api/resources/search?q=article");
+
+    const res = await searchResources(req, mockContext);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SuccessResponse<SearchResultsData>;
+    expect(body.data.resources).toEqual([
+      {
+        id: "article-1",
+        url: "https://example.com/article",
+        title: "Article",
+        description: "Useful reading",
+        tags: [{ id: "reading", name: "reading" }],
+        createdAt: "2024-01-04T00:00:00.000Z",
+        kind: "article",
+      },
+    ]);
     expect(mockDb.execute).toHaveBeenCalledTimes(2);
   });
 });

--- a/netlify/functions/get-resources.mts
+++ b/netlify/functions/get-resources.mts
@@ -24,7 +24,7 @@ interface PublicResource {
   description: string | null;
   tags: { id: string; name: string }[];
   createdAt: string;
-  kind: "resource" | "stack";
+  kind: "article" | "resource" | "stack";
   children?: Array<{
     id: string;
     url: string;
@@ -41,7 +41,7 @@ interface PublicResourceRow extends Record<string, unknown> {
   description: string | null;
   tags: string[];
   created_at: Date | string;
-  kind: "resource" | "stack";
+  kind: "article" | "resource" | "stack";
 }
 
 interface StackItemRow extends Record<string, unknown> {
@@ -107,7 +107,7 @@ async function getApprovedResourcesPage(
           public_listings.meta_description as description,
           public_listings.tags,
           public_listings.created_at,
-          'resource'::text as kind
+          public_listings.content_kind as kind
         from public_listings
         inner join resources on public_listings.resource_id = resources.id
         where public_listings.status = 'approved'

--- a/netlify/functions/search-resources.mts
+++ b/netlify/functions/search-resources.mts
@@ -24,7 +24,7 @@ interface PublicResource {
   description: string | null;
   tags: { id: string; name: string }[];
   createdAt: string;
-  kind: "resource" | "stack";
+  kind: "article" | "resource" | "stack";
   children?: Array<{
     id: string;
     url: string;
@@ -41,7 +41,7 @@ interface PublicResourceRow extends Record<string, unknown> {
   description: string | null;
   tags: string[];
   created_at: Date | string;
-  kind: "resource" | "stack";
+  kind: "article" | "resource" | "stack";
 }
 
 interface StackItemRow extends Record<string, unknown> {
@@ -178,7 +178,7 @@ async function searchApprovedResourcesPage(
           public_listings.meta_description as description,
           public_listings.tags,
           public_listings.created_at,
-          'resource'::text as kind
+          public_listings.content_kind as kind
         from public_listings
         inner join resources on public_listings.resource_id = resources.id
         where public_listings.status = 'approved'

--- a/src/api/__tests__/resources.test.ts
+++ b/src/api/__tests__/resources.test.ts
@@ -21,6 +21,15 @@ describe("resources API", () => {
                 description: "Useful reading",
                 tags: [{ id: "reading", name: "reading" }],
                 createdAt: "2024-01-01",
+                kind: "article",
+              },
+              {
+                id: "resource-1",
+                url: "https://example.com/reference",
+                title: "Example Reference",
+                description: "Useful reference",
+                tags: [{ id: "reference", name: "reference" }],
+                createdAt: "2024-01-01",
                 kind: "resource",
               },
               {
@@ -55,9 +64,11 @@ describe("resources API", () => {
 
     const result = await getResources();
 
-    expect(result.resources).toHaveLength(2);
-    expect(result.resources[1].kind).toBe("stack");
-    expect(result.resources[1].children).toHaveLength(1);
+    expect(result.resources).toHaveLength(3);
+    expect(result.resources[0].kind).toBe("article");
+    expect(result.resources[1].kind).toBe("resource");
+    expect(result.resources[2].kind).toBe("stack");
+    expect(result.resources[2].children).toHaveLength(1);
   });
 
   it("passes search params through", async () => {

--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -29,7 +29,7 @@ const resourceSchema = v.object({
   description: v.nullable(v.string()),
   tags: v.array(resourceTagSchema),
   createdAt: v.string(),
-  kind: v.picklist(["resource", "stack"]),
+  kind: v.picklist(["article", "resource", "stack"]),
   children: v.optional(v.array(resourceChildSchema)),
 });
 

--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -31,6 +31,18 @@ function getHostname(url: string): string {
   return parsedUrl.protocol === "mailto:" ? "" : parsedUrl.hostname.replace(/^www\./, "");
 }
 
+function getKindLabel(kind: Resource["kind"]): string {
+  if (kind === "stack") {
+    return "Stack";
+  }
+
+  if (kind === "article") {
+    return "Article";
+  }
+
+  return "Resource";
+}
+
 export function ResourceCard({ resource, onTagClick }: ResourceCardProps) {
   const titleId = useId();
   const isStack = resource.kind === "stack";
@@ -41,7 +53,7 @@ export function ResourceCard({ resource, onTagClick }: ResourceCardProps) {
       <div className="ResourceCard-main">
         {/* TODO: Rework the card-click pattern so the full card is clickable without wrapping all content in one anchor. */}
         <a href={resourceHref} className="ResourceCard-link" aria-labelledby={titleId}>
-          <span className="ResourceCard-kind ui-caption">{isStack ? "Stack" : "Resource"}</span>
+          <span className="ResourceCard-kind ui-caption">{getKindLabel(resource.kind)}</span>
           <h3 id={titleId} className="ResourceCard-title heading-base">
             {resource.title}
           </h3>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import {
   type AnyPgColumn,
   bigint,
+  check,
   index,
   pgSchema,
   pgTable,
@@ -111,6 +112,11 @@ export const publicListingsTable = pgTable(
     }),
     submitterName: text("submitter_name"),
     submitterGithubUrl: text("submitter_github_url"),
+    contentKind: text("content_kind", {
+      enum: ["article", "resource"],
+    })
+      .default("resource")
+      .notNull(),
     status: text("status", {
       enum: ["pending", "approved", "rejected"],
     }).notNull(),
@@ -139,6 +145,10 @@ export const publicListingsTable = pgTable(
     ),
     index("idx_public_listings_resource").on(table.resourceId),
     uniqueIndex("unique_public_listing_resource").on(table.resourceId),
+    check(
+      "public_listings_content_kind_check",
+      sql`${table.contentKind} in ('article', 'resource')`,
+    ),
   ],
 );
 


### PR DESCRIPTION
## Summary
- Add `article` as a valid public listing kind alongside `resource` and `stack`
- Read `content_kind` from approved listings in the Netlify resource functions
- Update API validation, resource card labels, and tests to preserve article kinds end to end

## Testing
- Updated unit tests for resource API and Netlify functions to cover article listings
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new “article” content type across listing and resource views.
  * Resource cards now display “Article” alongside existing item types.
  * Search and resource lists now preserve and show the correct item type for articles.

* **Bug Fixes**
  * Improved consistency between stored listing type and what appears in the UI and API responses.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->