### PR TITLE
Add public submission contracts for tools API

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -209,12 +209,13 @@ All responses follow a consistent envelope:
 
 Valibot schemas in `src/lib/validation.ts` define:
 
+- Shared public submissions for tools, articles, and resources (`publicSubmissionRequestSchema`, `publicSubmissionResponseSchema`)
 - Tool submission (`toolSubmissionSchema`)
 - Personal library entries (`personalResourceRequestSchema`)
 - Tag constraints (1–10 tags, max 50 chars each)
 - URL normalization rules (HTTP/HTTPS only, max 2000 chars)
 
-Functions call `validate*()` helpers; the frontend reuses the same schemas for form validation.
+Public submission success responses return a submitted item id, `tool | article | resource` type, moderation status, and message. Functions call `validate*()` helpers; the frontend reuses the same schemas for form validation.
 
 ### External service integrations
 

--- a/netlify/functions/__tests__/process-bookmark.test.ts
+++ b/netlify/functions/__tests__/process-bookmark.test.ts
@@ -4,7 +4,9 @@ import type { ErrorResponse, SuccessResponse } from "../lib/responses";
 
 /** Success data shape for process-bookmark */
 interface BookmarkCreated {
-  bookmarkId: string;
+  submittedItemId: string;
+  type: "tool";
+  status: "pending";
   message: string;
 }
 
@@ -68,7 +70,7 @@ function createMockDb() {
     values: vi.fn().mockReturnThis(),
     onConflictDoUpdate: vi.fn().mockReturnThis(),
     onConflictDoNothing: vi.fn().mockReturnThis(),
-    returning: vi.fn().mockResolvedValue([{ id: "test-bookmark-id" }]),
+    returning: vi.fn().mockResolvedValue([{ id: "11111111-1111-4111-8111-111111111111" }]),
     innerJoin: vi.fn().mockReturnThis(),
     leftJoin: vi.fn().mockReturnThis(),
     orderBy: vi.fn().mockReturnThis(),
@@ -135,7 +137,7 @@ describe("process-bookmark", () => {
     it("returns 422 for missing URL", async () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
-        body: JSON.stringify({ tags: ["test"] }),
+        body: JSON.stringify({ type: "tool", tags: ["test"] }),
         headers: { "Content-Type": "application/json" },
       });
 
@@ -149,7 +151,7 @@ describe("process-bookmark", () => {
     it("returns 422 for missing tags", async () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
-        body: JSON.stringify({ url: "https://example.com" }),
+        body: JSON.stringify({ type: "tool", url: "https://example.com" }),
         headers: { "Content-Type": "application/json" },
       });
 
@@ -163,13 +165,31 @@ describe("process-bookmark", () => {
     it("returns 422 for invalid URL format", async () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
-        body: JSON.stringify({ url: "not-a-url", tags: ["test"] }),
+        body: JSON.stringify({ type: "tool", url: "not-a-url", tags: ["test"] }),
         headers: { "Content-Type": "application/json" },
       });
 
       const res = await processBookmark(req, mockContext);
 
       expect(res.status).toBe(422);
+    });
+
+    it("returns 422 when the tools endpoint receives a non-tool submission", async () => {
+      const req = new Request("https://test.com/api/tools", {
+        method: "POST",
+        body: JSON.stringify({
+          type: "article",
+          url: "https://example.com/article",
+          tags: ["test"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const res = await processBookmark(req, mockContext);
+
+      expect(res.status).toBe(422);
+      const body = (await res.json()) as ErrorResponse;
+      expect(body.details?.type).toContain("/api/tools only accepts tool submissions");
     });
 
     it("returns generic 503 when required env vars are missing", async () => {
@@ -182,6 +202,7 @@ describe("process-bookmark", () => {
         const req = new Request("https://test.com/api/tools", {
           method: "POST",
           body: JSON.stringify({
+            type: "tool",
             url: "https://example.com/tool",
             tags: ["test"],
           }),
@@ -210,6 +231,7 @@ describe("process-bookmark", () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
         body: JSON.stringify({
+          type: "tool",
           url: "https://example.com",
           tags: ["test"],
         }),
@@ -225,10 +247,11 @@ describe("process-bookmark", () => {
   });
 
   describe("successful submission", () => {
-    it("returns 201 with bookmark ID on success", async () => {
+    it("returns 201 with public submission status data on success", async () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
         body: JSON.stringify({
+          type: "tool",
           url: "https://example.com/tool",
           tags: ["javascript", "testing"],
         }),
@@ -240,7 +263,9 @@ describe("process-bookmark", () => {
       expect(res.status).toBe(201);
       const body = (await res.json()) as SuccessResponse<BookmarkCreated>;
       expect(body.success).toBe(true);
-      expect(body.data.bookmarkId).toBeDefined();
+      expect(body.data.submittedItemId).toBeDefined();
+      expect(body.data.type).toBe("tool");
+      expect(body.data.status).toBe("pending");
       expect(body.data.message).toContain("submitted");
     });
 
@@ -248,6 +273,7 @@ describe("process-bookmark", () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
         body: JSON.stringify({
+          type: "tool",
           url: "https://example.com/tool",
           tags: ["test"],
         }),
@@ -269,6 +295,7 @@ describe("process-bookmark", () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
         body: JSON.stringify({
+          type: "tool",
           url: "https://example.com/tool",
           tags: ["test"],
         }),
@@ -296,6 +323,7 @@ describe("process-bookmark", () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
         body: JSON.stringify({
+          type: "tool",
           url: "https://example.com/tool",
           tags: ["test"],
         }),
@@ -312,6 +340,7 @@ describe("process-bookmark", () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
         body: JSON.stringify({
+          type: "tool",
           url: "https://example.com/tool",
           tags: ["JavaScript", "TESTING"],
         }),

--- a/netlify/functions/process-bookmark.mts
+++ b/netlify/functions/process-bookmark.mts
@@ -21,7 +21,7 @@ import {
 import { extractMetadata } from "../../src/lib/services/metadata";
 import { captureScreenshot } from "../../src/lib/services/screenshot";
 import { uploadScreenshot } from "../../src/lib/services/cloudinary";
-import { validateBookmarkRequest } from "../../src/lib/validation";
+import { validatePublicSubmissionRequest } from "../../src/lib/validation";
 
 const FALLBACK_IMAGE = "/makerbench-fallback.png";
 
@@ -62,9 +62,15 @@ export default async (req: Request, _context: Context) => {
     return validationError("Invalid JSON in request body");
   }
 
-  const validation = validateBookmarkRequest(body);
+  const validation = validatePublicSubmissionRequest(body);
   if (!validation.success) {
     return validationError("Validation failed", getValidationDetails(validation.issues));
+  }
+
+  if (validation.output.type !== "tool") {
+    return validationError("Validation failed", {
+      type: ["/api/tools only accepts tool submissions"],
+    });
   }
 
   const {
@@ -146,7 +152,9 @@ export default async (req: Request, _context: Context) => {
     }
 
     return created({
-      bookmarkId: tool.id,
+      submittedItemId: tool.id,
+      type: "tool",
+      status: "pending",
       message: "Tool submitted. It will be reviewed shortly.",
     });
   } catch (error) {

--- a/src/api/__tests__/bookmarks.test.ts
+++ b/src/api/__tests__/bookmarks.test.ts
@@ -136,7 +136,7 @@ function createGetTagsHandler() {
  */
 function createSubmitBookmarkHandler() {
   return http.post(`${API_BASE}/api/tools`, async ({ request }) => {
-    const body = (await request.json()) as { url?: string; tags?: string[] };
+    const body = (await request.json()) as { type?: string; url?: string; tags?: string[] };
 
     // Validate URL is present
     if (!body.url) {
@@ -145,6 +145,17 @@ function createSubmitBookmarkHandler() {
           success: false,
           error: "Validation failed",
           details: { url: ["URL is required"] },
+        },
+        { status: 422 },
+      );
+    }
+
+    if (body.type !== "tool") {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: "Validation failed",
+          details: { type: ["/api/tools only accepts tool submissions"] },
         },
         { status: 422 },
       );
@@ -165,7 +176,9 @@ function createSubmitBookmarkHandler() {
       {
         success: true,
         data: {
-          bookmarkId: "new-bookmark-id",
+          submittedItemId: "11111111-1111-4111-8111-111111111111",
+          type: "tool",
+          status: "pending",
           message: "Bookmark submitted. It will be reviewed shortly.",
         },
       },
@@ -304,7 +317,9 @@ describe("submitBookmark", () => {
       tags: ["typescript"],
     });
 
-    expect(result.bookmarkId).toBe("new-bookmark-id");
+    expect(result.submittedItemId).toBe("11111111-1111-4111-8111-111111111111");
+    expect(result.type).toBe("tool");
+    expect(result.status).toBe("pending");
     expect(result.message).toContain("submitted");
   });
 

--- a/src/api/bookmarks.ts
+++ b/src/api/bookmarks.ts
@@ -1,5 +1,10 @@
 import * as v from "valibot";
-import type { BookmarkRequest } from "../lib/validation";
+import {
+  apiErrorResponseSchema,
+  publicSubmissionResponseSchema,
+  type BookmarkRequest,
+  type PublicSubmissionResponseData,
+} from "../lib/validation";
 
 function getBaseUrl(): string {
   if (typeof window !== "undefined") {
@@ -53,25 +58,9 @@ const bookmarksResponseSchema = v.object({
   data: bookmarksDataSchema,
 });
 
-const submitDataSchema = v.object({
-  bookmarkId: v.string(),
-  message: v.string(),
-});
-
-const submitResponseSchema = v.object({
-  success: v.literal(true),
-  data: submitDataSchema,
-});
-
 const tagsResponseSchema = v.object({
   success: v.literal(true),
   data: tagsDataSchema,
-});
-
-const errorResponseSchema = v.object({
-  success: v.literal(false),
-  error: v.string(),
-  details: v.optional(v.record(v.string(), v.array(v.string()))),
 });
 
 // TODO(#61): These bookmark* schemas are legacy compatibility exports for the
@@ -83,8 +72,8 @@ export type PaginationInfo = v.InferOutput<typeof paginationSchema>;
 export type Bookmark = v.InferOutput<typeof bookmarkSchema>;
 export type BookmarksResponse = v.InferOutput<typeof bookmarksDataSchema>;
 export type TagsResponse = v.InferOutput<typeof tagsDataSchema>;
-export type SubmitBookmarkResponse = v.InferOutput<typeof submitDataSchema>;
-export type ApiError = v.InferOutput<typeof errorResponseSchema>;
+export type SubmitBookmarkResponse = PublicSubmissionResponseData;
+export type ApiError = v.InferOutput<typeof apiErrorResponseSchema>;
 
 export type Tool = Bookmark;
 export type ToolsResponse = BookmarksResponse;
@@ -123,7 +112,7 @@ export class BookmarkApiError extends Error {
 }
 
 function throwApiError(json: unknown, status: number): never {
-  const parsed = v.safeParse(errorResponseSchema, json);
+  const parsed = v.safeParse(apiErrorResponseSchema, json);
   throw new BookmarkApiError(
     parsed.success ? parsed.output.error : "An unexpected error occurred",
     status,
@@ -246,6 +235,7 @@ export async function submitBookmark(data: BookmarkRequest): Promise<SubmitBookm
   const { submitterGithubUsername, submitterGithubUrl, ...rest } = data;
   const payload = {
     ...rest,
+    type: "tool",
     submitterGithubUrl: submitterGithubUsername
       ? `https://github.com/${submitterGithubUsername}`
       : submitterGithubUrl,
@@ -265,7 +255,7 @@ export async function submitBookmark(data: BookmarkRequest): Promise<SubmitBookm
     throwApiError(json, response.status);
   }
 
-  const result = v.safeParse(submitResponseSchema, json);
+  const result = v.safeParse(publicSubmissionResponseSchema, json);
   if (!result.success) {
     throw new BookmarkApiError("Invalid response from server", 500);
   }

--- a/src/hooks/__tests__/useSubmitBookmark.test.tsx
+++ b/src/hooks/__tests__/useSubmitBookmark.test.tsx
@@ -35,7 +35,9 @@ function createSubmitHandler() {
       {
         success: true,
         data: {
-          bookmarkId: "new-bookmark-id",
+          submittedItemId: "11111111-1111-4111-8111-111111111111",
+          type: "tool",
+          status: "pending",
           message: "Bookmark submitted successfully",
         },
       },
@@ -75,9 +77,12 @@ describe("useSubmitBookmark", () => {
 
     expect(result.current.isSubmitting).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(result.current.response?.bookmarkId).toBe("new-bookmark-id");
+    expect(result.current.response?.submittedItemId).toBe(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    expect(result.current.response?.status).toBe("pending");
     expect(result.current.response?.message).toContain("successfully");
-    expect(submitResult?.bookmarkId).toBe("new-bookmark-id");
+    expect(submitResult?.submittedItemId).toBe("11111111-1111-4111-8111-111111111111");
   });
 
   it("sets isSubmitting during request", async () => {

--- a/src/lib/__tests__/github.test.ts
+++ b/src/lib/__tests__/github.test.ts
@@ -1,7 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { getGithubUsernameFromProfileUrl, isValidGithubProfileUrl } from "../github";
+import {
+  getGithubUsernameFromProfileUrl,
+  isValidGithubProfileUrl,
+  isValidGithubUsername,
+} from "../github";
 
 describe("github utils", () => {
+  describe("isValidGithubUsername", () => {
+    it("accepts username values used in profile URLs", () => {
+      expect(isValidGithubUsername("octocat")).toBe(true);
+      expect(isValidGithubUsername("octo-cat")).toBe(true);
+      expect(isValidGithubUsername("octocat123")).toBe(true);
+    });
+
+    it("rejects values that cannot be GitHub profile username segments", () => {
+      expect(isValidGithubUsername("-octocat")).toBe(false);
+      expect(isValidGithubUsername("octocat-")).toBe(false);
+      expect(isValidGithubUsername("octocat/repo")).toBe(false);
+      expect(isValidGithubUsername("josé")).toBe(false);
+      expect(isValidGithubUsername("a".repeat(40))).toBe(false);
+    });
+  });
+
   describe("isValidGithubProfileUrl", () => {
     it("accepts valid profile URLs", () => {
       expect(isValidGithubProfileUrl("https://github.com/octocat")).toBe(true);

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   validateToolSubmission,
   validatePersonalResourceRequest,
+  validatePublicSubmissionRequest,
+  validatePublicSubmissionResponse,
   validateUrl,
   validateTags,
   parseTagsFromString,
@@ -87,6 +89,107 @@ describe("Validation Schemas", () => {
       });
 
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe("validatePublicSubmissionRequest", () => {
+    it.each(["tool", "article", "resource"] as const)(
+      "should validate %s public submissions",
+      (type) => {
+        const result = validatePublicSubmissionRequest({
+          type,
+          url: `https://example.com/${type}`,
+          tags: ["development"],
+        });
+
+        expect(result.success).toBe(true);
+      },
+    );
+
+    it("should validate optional anonymous submitter attribution", () => {
+      const result = validatePublicSubmissionRequest({
+        type: "resource",
+        url: "https://example.com/resource",
+        tags: ["reference"],
+        submitterName: "Zoë Álvarez",
+        submitterGithubUrl: "https://github.com/alexmaker",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject invalid GitHub usernames without constraining display names to ASCII", () => {
+      expect(
+        validatePublicSubmissionRequest({
+          type: "tool",
+          url: "https://example.com/tool",
+          tags: ["development"],
+          submitterName: "Renée Developer",
+          submitterGithubUsername: "renée-dev",
+        }).success,
+      ).toBe(false);
+
+      expect(
+        validatePublicSubmissionRequest({
+          type: "tool",
+          url: "https://example.com/tool",
+          tags: ["development"],
+          submitterName: "Renée Developer",
+          submitterGithubUsername: "renee-dev",
+        }).success,
+      ).toBe(true);
+    });
+
+    it("should validate optional authenticated user context", () => {
+      const result = validatePublicSubmissionRequest({
+        type: "article",
+        url: "https://example.com/article",
+        tags: ["writing"],
+        authenticatedUser: {
+          userId: "11111111-1111-4111-8111-111111111111",
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject unsupported public submission types", () => {
+      const result = validatePublicSubmissionRequest({
+        type: "video",
+        url: "https://example.com/video",
+        tags: ["media"],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject invalid authenticated user ids", () => {
+      const result = validatePublicSubmissionRequest({
+        type: "resource",
+        url: "https://example.com/resource",
+        tags: ["reference"],
+        authenticatedUser: {
+          userId: "not-a-user-id",
+        },
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("validatePublicSubmissionResponse", () => {
+    it("should validate standardized pending review response data", () => {
+      const result = validatePublicSubmissionResponse({
+        success: true,
+        data: {
+          submittedItemId: "11111111-1111-4111-8111-111111111111",
+          type: "tool",
+          status: "pending",
+          message: "Tool submitted. It will be reviewed shortly.",
+        },
+      });
+
+      expect(result.success).toBe(true);
     });
   });
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -3,7 +3,15 @@
  */
 
 const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
+export const GITHUB_USERNAME_MAX_LENGTH = 39;
 const GITHUB_USERNAME_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+
+/**
+ * Returns true when a value can be used as a GitHub profile username segment.
+ */
+export function isValidGithubUsername(username: string): boolean {
+  return username.length <= GITHUB_USERNAME_MAX_LENGTH && GITHUB_USERNAME_PATTERN.test(username);
+}
 
 /**
  * Returns true when URL is a GitHub profile URL in the form:
@@ -30,7 +38,7 @@ export function isValidGithubProfileUrl(url: string): boolean {
       return false;
     }
 
-    return GITHUB_USERNAME_PATTERN.test(pathSegments[0]);
+    return isValidGithubUsername(pathSegments[0]);
   } catch {
     return false;
   }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,5 +1,9 @@
 import * as v from "valibot";
-import { isValidGithubProfileUrl } from "./github";
+import {
+  GITHUB_USERNAME_MAX_LENGTH,
+  isValidGithubProfileUrl,
+  isValidGithubUsername,
+} from "./github";
 
 const urlSchema = v.pipe(v.string(), v.url("Please enter a valid URL"));
 const MAX_URL_LENGTH = 2000;
@@ -44,6 +48,60 @@ const githubProfileUrlSchema = v.pipe(
 
 const optionalGithubProfileUrlSchema = v.optional(v.union([githubProfileUrlSchema, v.literal("")]));
 
+const optionalSubmitterNameSchema = v.optional(
+  v.pipe(v.string(), v.maxLength(100, "Name must be 100 characters or less")),
+);
+
+const optionalGithubUsernameSchema = v.optional(
+  v.union([
+    v.pipe(
+      v.string(),
+      v.maxLength(
+        GITHUB_USERNAME_MAX_LENGTH,
+        `GitHub username must be ${GITHUB_USERNAME_MAX_LENGTH} characters or less`,
+      ),
+      v.check(isValidGithubUsername, "Please enter a valid GitHub username"),
+    ),
+    v.literal(""),
+  ]),
+);
+
+export const publicSubmissionTypeSchema = v.picklist(["tool", "article", "resource"]);
+export const publicSubmissionStatusSchema = v.picklist(["pending", "approved", "rejected"]);
+
+export const publicSubmissionAuthenticatedUserSchema = v.object({
+  userId: v.pipe(v.string(), v.uuid("Authenticated user id must be a valid UUID")),
+});
+
+// Server-side code should populate this from verified auth context, not trust arbitrary client JSON.
+export const publicSubmissionRequestSchema = v.object({
+  type: publicSubmissionTypeSchema,
+  url: resourceUrlSchema,
+  tags: resourceTagsSchema,
+  submitterName: optionalSubmitterNameSchema,
+  submitterGithubUsername: optionalGithubUsernameSchema,
+  submitterGithubUrl: optionalGithubProfileUrlSchema,
+  authenticatedUser: v.optional(publicSubmissionAuthenticatedUserSchema),
+});
+
+export const publicSubmissionResponseDataSchema = v.object({
+  submittedItemId: v.pipe(v.string(), v.uuid()),
+  type: publicSubmissionTypeSchema,
+  status: publicSubmissionStatusSchema,
+  message: v.string(),
+});
+
+export const publicSubmissionResponseSchema = v.object({
+  success: v.literal(true),
+  data: publicSubmissionResponseDataSchema,
+});
+
+export const apiErrorResponseSchema = v.object({
+  success: v.literal(false),
+  error: v.string(),
+  details: v.optional(v.record(v.string(), v.array(v.string()))),
+});
+
 export const tagSchema = v.object({
   id: v.pipe(v.string(), v.uuid()),
   name: v.pipe(
@@ -70,31 +128,15 @@ export const toolSubmissionSchema = v.object({
     v.array(v.pipe(v.string(), v.minLength(1, "Tag cannot be empty"))),
     v.minLength(1, "At least one tag is required"),
   ),
-  submitterName: v.optional(
-    v.pipe(v.string(), v.maxLength(100, "Name must be 100 characters or less")),
-  ),
+  submitterName: optionalSubmitterNameSchema,
   submitterGithubUrl: optionalGithubProfileUrlSchema,
 });
 
 export const bookmarkRequestSchema = v.object({
   url: resourceUrlSchema,
   tags: resourceTagsSchema,
-  submitterName: v.optional(
-    v.pipe(v.string(), v.maxLength(100, "Name must be 100 characters or less")),
-  ),
-  submitterGithubUsername: v.optional(
-    v.union([
-      v.pipe(
-        v.string(),
-        v.maxLength(39, "GitHub username must be 39 characters or less"),
-        v.regex(
-          /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/,
-          "Please enter a valid GitHub username",
-        ),
-      ),
-      v.literal(""),
-    ]),
-  ),
+  submitterName: optionalSubmitterNameSchema,
+  submitterGithubUsername: optionalGithubUsernameSchema,
   submitterGithubUrl: optionalGithubProfileUrlSchema,
 });
 
@@ -150,6 +192,11 @@ export type Submitter = v.InferOutput<typeof submitterSchema>;
 export type ToolSubmissionData = v.InferOutput<typeof toolSubmissionSchema>;
 export type BookmarkRequest = v.InferOutput<typeof bookmarkRequestSchema>;
 export type PersonalResourceRequest = v.InferOutput<typeof personalResourceRequestSchema>;
+export type PublicSubmissionType = v.InferOutput<typeof publicSubmissionTypeSchema>;
+export type PublicSubmissionStatus = v.InferOutput<typeof publicSubmissionStatusSchema>;
+export type PublicSubmissionRequest = v.InferOutput<typeof publicSubmissionRequestSchema>;
+export type PublicSubmissionResponseData = v.InferOutput<typeof publicSubmissionResponseDataSchema>;
+export type ApiErrorResponse = v.InferOutput<typeof apiErrorResponseSchema>;
 export type ToolMetadata = v.InferOutput<typeof toolMetadataSchema>;
 export type Tool = v.InferOutput<typeof toolSchema>;
 export type SearchRequest = v.InferOutput<typeof searchRequestSchema>;
@@ -166,6 +213,14 @@ export const validateBookmarkRequest = (data: unknown) => {
 
 export const validatePersonalResourceRequest = (data: unknown) => {
   return v.safeParse(personalResourceRequestSchema, data);
+};
+
+export const validatePublicSubmissionRequest = (data: unknown) => {
+  return v.safeParse(publicSubmissionRequestSchema, data);
+};
+
+export const validatePublicSubmissionResponse = (data: unknown) => {
+  return v.safeParse(publicSubmissionResponseSchema, data);
 };
 
 export const validateSearchRequest = (data: unknown) => {


### PR DESCRIPTION
## Summary
- Introduce shared Valibot schemas for public submissions and standardized moderation responses
- Update the tools submission endpoint and client to require `type: "tool"` and return `submittedItemId`, `type`, `status`, and `message`
- Tighten GitHub username validation and add coverage for request, response, and endpoint behavior

## Testing
- Unit tests added/updated for validation helpers, GitHub username validation, API client parsing, and the tools function contract
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for public submissions with shared validation across tools, articles, and resources.
  * Standardized successful submission responses to include submission ID, item type, and pending review status.

* **Bug Fixes**
  * Improved request validation so tool submissions are correctly accepted or rejected with clearer errors.
  * Tightened GitHub username checks, including length limits and invalid character handling.

* **Tests**
  * Expanded coverage for public submission validation, response handling, and GitHub profile username rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->