### PR TITLE
docs: update Supabase setup and deployment runbooks

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -43,8 +43,8 @@ The application sends the current browser origin as the OAuth redirect URL.
 
 ## Environment variables
 
-`.env.schema` is the source of truth for local variable names and the checked-in
-Varlock/1Password references. Use the exact names below:
+`.env.schema` is the source of truth for required local variable names and the
+checked-in Varlock/1Password references. Use the exact names below:
 
 | Variable | Scope | Purpose |
 | --- | --- | --- |
@@ -56,10 +56,11 @@ Varlock/1Password references. Use the exact names below:
 | `CLOUDINARY_API_SECRET` | Server only | Cloudinary API secret |
 | `BROWSERLESS_API_KEY` | Server only | Browserless screenshot API key |
 
-`SENTRY_DSN` is an optional server-side variable supported by the Functions.
-Netlify supplies `CONTEXT` automatically for Sentry environment tagging. Do
-not add `VITE_` to server-only secrets, and use the variable names in
-`.env.schema` for the active application setup.
+`SENTRY_DSN` is a separate optional server-side setting supported by the
+Functions; it is not required by `.env.schema`. Netlify supplies `CONTEXT`
+automatically for Sentry environment tagging. Do not add `VITE_` to server-only
+secrets, and use the required variable names in `.env.schema` for the active
+application setup.
 
 ## Apply the database schema
 

--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -1,49 +1,105 @@
-# Database Setup (Turso)
+# Database Setup (Supabase Postgres)
 
-Last updated: February 26, 2026
+Last updated: July 11, 2026
 
-This document covers Turso setup only.
-For complete app setup and deployment, see:
+MakerBench uses Supabase Postgres as its canonical database and Supabase Auth
+for Google and GitHub sign-in. Netlify Functions connect to Postgres through
+Drizzle, while the browser uses the Supabase URL and anon key for auth.
 
-- Local runbook: [docs/local-development.md](./docs/local-development.md)
-- Production runbook: [docs/production-deployment.md](./docs/production-deployment.md)
+For the complete workflows, see:
+
+- Local development: [docs/local-development.md](./docs/local-development.md)
+- Production deployment: [docs/production-deployment.md](./docs/production-deployment.md)
 
 ## Prerequisites
 
-- Turso CLI: https://docs.turso.tech/cli/installation
-- Turso account: https://turso.tech
+- A Supabase project with access to its database and Auth settings
+- Node.js 24.x
+- pnpm 11.5.0, as pinned by `package.json`
+- The repository's Varlock and 1Password setup for resolving `.env.schema`
 
-## Create a database
+## Create or select the Supabase project
+
+1. Create a Supabase project, or select the existing MakerBench project.
+2. In the Supabase dashboard, open the database connection details and copy a
+   PostgreSQL connection string. Use the Supabase pooler connection string for
+   serverless workloads when available.
+3. Keep the connection string server-only. It must only be provided as
+   `SUPABASE_DATABASE_URL` and must never be bundled into the Vite client.
+
+## Configure Supabase Auth
+
+The application calls Supabase Auth with the `google` and `github` providers.
+Enable and configure those providers in the Supabase dashboard if they are
+needed for the environment.
+
+In Supabase Auth URL configuration, allow the application origins used by the
+environment:
+
+- The local origin printed by `netlify dev`
+- The production Netlify site URL
+
+The application sends the current browser origin as the OAuth redirect URL.
+
+## Environment variables
+
+`.env.schema` is the source of truth for local variable names and the checked-in
+Varlock/1Password references. Use the exact names below:
+
+| Variable | Scope | Purpose |
+| --- | --- | --- |
+| `SUPABASE_DATABASE_URL` | Server only | Supabase Postgres connection string |
+| `VITE_SUPABASE_URL` | Client and server | Supabase project URL |
+| `VITE_SUPABASE_ANON_KEY` | Client and server | Supabase anon key for browser auth and server JWT verification |
+| `CLOUDINARY_CLOUD_NAME` | Server only | Cloudinary cloud name |
+| `CLOUDINARY_API_KEY` | Server only | Cloudinary API key |
+| `CLOUDINARY_API_SECRET` | Server only | Cloudinary API secret |
+| `BROWSERLESS_API_KEY` | Server only | Browserless screenshot API key |
+
+`SENTRY_DSN` is an optional server-side variable supported by the Functions.
+Netlify supplies `CONTEXT` automatically for Sentry environment tagging. Do
+not add `VITE_` to server-only secrets, and use the variable names in
+`.env.schema` for the active application setup.
+
+## Apply the database schema
+
+Install dependencies and apply the committed PostgreSQL migrations from the
+project root:
 
 ```bash
-turso auth login
-turso db create makerbench-db
-turso db show --url makerbench-db
-turso db tokens create makerbench-db
+pnpm install
+pnpm db:migrate
 ```
 
-Use the returned values for:
+Drizzle Kit reads `SUPABASE_DATABASE_URL` through `drizzle.config.ts`. The
+migrations live in `migrations/postgres/`, and the journal in
+`migrations/postgres/meta/` is part of the migration history.
 
-- `TURSO_DATABASE_URL`
-- `TURSO_AUTH_TOKEN`
-
-## Apply schema
-
-From the project root:
+When `src/db/schema.ts` changes:
 
 ```bash
-npx drizzle-kit push
+pnpm db:generate
+pnpm db:migrate
 ```
 
-If `src/db/schema.ts` changed:
+Review the generated SQL, commit the migration and its journal metadata, and
+apply it to the target Supabase project before deploying code that depends on
+it. Do not use `drizzle-kit push` for the active workflow; schema changes must
+be represented by committed migrations.
+
+## Historical Turso import
+
+Turso is no longer the active database. The repository retains
+`scripts/import-makerbench-turso.ts` only to import historical Turso export
+data into the current Postgres schema when needed.
+
+The package script performs a dry run by default:
 
 ```bash
-npx drizzle-kit generate
-npx drizzle-kit push
+pnpm migrate:makerbench-turso --source=./makerbench-export.json
 ```
 
-## Environment variable usage
-
-- Drizzle Kit reads from `process.env` (see `drizzle.config.ts`).
-- Netlify Functions read from `Netlify.env.get(...)`.
-- Do not use `VITE_` prefixes for these database variables.
+After reviewing the dry-run output, `--execute` writes to the configured
+Supabase Postgres database. Treat the export as untrusted input, keep database
+credentials out of the export and command history, and do not use the Turso
+CLI for normal development or deployment.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -30,10 +30,11 @@ Netlify builds.
 
 ## 2. Configure environment variables
 
-Use [`.env.schema`](../.env.schema) as the canonical list of local variables.
-Resolve its Varlock/1Password references using the repository's normal local
-environment workflow before starting Netlify Dev or running Drizzle commands.
-Do not commit resolved secrets or create a second checked-in environment file.
+Use [`.env.schema`](../.env.schema) as the canonical list of required local
+variables managed through Varlock. Resolve its Varlock/1Password references
+using the repository's normal local environment workflow before starting
+Netlify Dev or running Drizzle commands. Do not commit resolved secrets or
+create a second checked-in environment file.
 
 The required names are:
 
@@ -45,10 +46,10 @@ The required names are:
 - `CLOUDINARY_API_SECRET`
 - `BROWSERLESS_API_KEY`
 
-`SENTRY_DSN` is optional and is read by the Functions when configured. The
-`VITE_` variables are exposed to the browser by Vite; the database and service
-credentials are server-side values. Netlify Functions read their values from
-`Netlify.env`.
+`SENTRY_DSN` is a separate optional setting read by the Functions when
+configured; it is not required by `.env.schema`. The `VITE_` variables are
+exposed to the browser by Vite; the database and service credentials are
+server-side values. Netlify Functions read their values from `Netlify.env`.
 
 ## 3. Apply Supabase migrations
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,13 +1,23 @@
 # Local Development
 
-Last updated: May 30, 2026
+Last updated: July 11, 2026
+
+MakerBench runs locally as a Vite React frontend plus Netlify Functions. Use
+Supabase Postgres for data, Supabase Auth for sign-in, and Netlify Dev so the
+frontend and `/api/*` Functions share one local workflow.
+
+Related runbooks:
+
+- Database details: [../DATABASE_SETUP.md](../DATABASE_SETUP.md)
+- Production deployment: [production-deployment.md](./production-deployment.md)
 
 ## Prerequisites
 
 - Node.js 24.x
-- pnpm (latest)
-- Netlify CLI (recommended): `pnpm add -g netlify-cli`
-- Turso database + auth token
+- pnpm 11.5.0, as pinned by `package.json`
+- Netlify CLI (`pnpm add --global netlify-cli`)
+- A Supabase project and its Postgres/Auth configuration
+- Access to the repository's Varlock and 1Password setup
 
 ## 1. Install dependencies
 
@@ -15,70 +25,76 @@ Last updated: May 30, 2026
 pnpm install
 ```
 
-Package manager note:
-
-- This repository pins `pnpm` via `packageManager` in `package.json` to ensure Netlify Corepack resolves the same pnpm version used locally.
+The repository pins pnpm in `package.json`, so use that version locally and in
+Netlify builds.
 
 ## 2. Configure environment variables
 
-Copy the example file and set values:
+Use [`.env.schema`](../.env.schema) as the canonical list of local variables.
+Resolve its Varlock/1Password references using the repository's normal local
+environment workflow before starting Netlify Dev or running Drizzle commands.
+Do not commit resolved secrets or create a second checked-in environment file.
 
-```bash
-cp .env.example .env
-```
+The required names are:
 
-Required variables for full local functionality:
-
-- `TURSO_DATABASE_URL`
-- `TURSO_AUTH_TOKEN`
-- `BROWSERLESS_API_KEY`
+- `SUPABASE_DATABASE_URL` - server-only Supabase Postgres connection string
+- `VITE_SUPABASE_URL` - Supabase project URL
+- `VITE_SUPABASE_ANON_KEY` - Supabase anon key for browser auth
 - `CLOUDINARY_CLOUD_NAME`
 - `CLOUDINARY_API_KEY`
 - `CLOUDINARY_API_SECRET`
-- `SENTRY_DSN` (optional)
+- `BROWSERLESS_API_KEY`
 
-Notes:
+`SENTRY_DSN` is optional and is read by the Functions when configured. The
+`VITE_` variables are exposed to the browser by Vite; the database and service
+credentials are server-side values. Netlify Functions read their values from
+`Netlify.env`.
 
-- These are server-side variables used by Netlify Functions.
-- Do not prefix with `VITE_`.
+## 3. Apply Supabase migrations
 
-## 3. Initialize database schema
-
-Push the schema to your Turso database:
-
-```bash
-npx drizzle-kit push
-```
-
-If you changed `src/db/schema.ts`, generate a migration before pushing:
+From the project root, apply the committed PostgreSQL migration history:
 
 ```bash
-npx drizzle-kit generate
-npx drizzle-kit push
+pnpm db:migrate
 ```
+
+When `src/db/schema.ts` changes, generate and then apply a migration:
+
+```bash
+pnpm db:generate
+pnpm db:migrate
+```
+
+Review generated SQL before committing it. Do not use `drizzle-kit push` for
+the project workflow. See [Database setup](../DATABASE_SETUP.md) for the
+Supabase project, Auth, and migration details.
 
 ## 4. Run the app locally
 
-Use Netlify Dev so both frontend and functions run together:
+Start Netlify Dev after the environment has been resolved:
 
 ```bash
 netlify dev
 ```
 
-Why not `pnpm dev` only?
+Use the URL printed by Netlify Dev. It proxies the Vite frontend and Netlify
+Functions together, which is required for `/api/*` requests. Plain `pnpm dev`
+only starts Vite and is useful for frontend-only work, not full end-to-end
+local behavior.
 
-- The app calls `/api/...` endpoints.
-- Those endpoints are Netlify Functions, so plain Vite dev server is not enough for end-to-end local behavior.
+If OAuth is being tested, add the local URL printed by Netlify Dev to the
+allowed redirect URLs in Supabase Auth settings. The app uses the current
+browser origin for the redirect.
 
 ## 5. Verify local setup
 
-Checklist:
-
-1. Open app at the URL printed by `netlify dev`.
-2. Home page loads without console/API errors.
-3. Submit a bookmark from `/submit`.
-4. `GET /api/bookmarks` returns JSON (approved bookmarks only).
-5. `GET /api/bookmarks/search?q=...` returns JSON.
+1. Open the URL printed by `netlify dev`.
+2. Confirm the home page loads without console or API errors.
+3. Sign in with a configured Supabase Auth provider if auth is being tested.
+4. Submit a bookmark from `/submit`.
+5. Confirm `GET /api/tools` returns approved tools.
+6. Confirm `GET /api/tools/search?q=...` returns JSON.
+7. Confirm authenticated library requests work at `/library`.
 
 ## 6. Quality checks
 
@@ -88,39 +104,49 @@ pnpm lint:css
 pnpm typecheck
 pnpm test
 pnpm build
-npx vitest --project storybook run   # Storybook interaction tests (requires Playwright Chromium)
-```
-
-## 7. Storybook (component workshop)
-
-Storybook runs the UI in isolation with the same CSS, auth/router decorators, and MSW handlers as the shared preview.
-
-```bash
-pnpm storybook              # http://localhost:6006
-pnpm build-storybook        # static output in storybook-static/
 npx vitest --project storybook run
 ```
 
-Stories are colocated with components (`src/components/**/*.stories.tsx`). Configuration lives in `.storybook/`. MSW mocks API routes used by the preview (`/api/auth/whoami`, `/api/tools`, `/api/resources`).
+The Storybook interaction tests require the Playwright Chromium browser. Run
+`npx playwright install chromium` once if the executable is not installed.
 
-**Current coverage (May 2026):** Button, Alert, LoadMoreButton, ResultCount, TagBadge, TagCloud, SearchInput, TagInput, ToolCard, ToolCardSkeleton. Page and layout components are not yet storied.
+## 7. Storybook
 
-**Playwright for story tests:** if browser tests fail with a missing Chromium executable, run `npx playwright install chromium` once.
+Storybook runs the UI in isolation with the same CSS, auth/router decorators,
+and MSW handlers as the shared preview:
+
+```bash
+pnpm storybook
+pnpm build-storybook
+npx vitest --project storybook run
+```
+
+Stories are colocated with components under `src/components/`. Configuration
+lives in `.storybook/`.
 
 ## Troubleshooting
 
-## `TURSO_DATABASE_URL not configured`
+### Supabase or Auth variables are missing
 
-- Confirm `.env` exists and includes `TURSO_DATABASE_URL`.
-- Restart `netlify dev` after env changes.
+- Confirm the values from `.env.schema` have been resolved before starting
+  Netlify Dev.
+- Confirm the names are exactly `SUPABASE_DATABASE_URL`,
+  `VITE_SUPABASE_URL`, and `VITE_SUPABASE_ANON_KEY`.
+- Restart `netlify dev` after changing environment values.
 
-## Bookmark submission returns fallback image often
+### Bookmark submission cannot capture an image
 
-- This can happen when:
-  - target page has no OG image, and
-  - `BROWSERLESS_API_KEY` is missing/invalid, or screenshot capture fails.
+Confirm `BROWSERLESS_API_KEY` is available. If Browserless is unavailable or
+the target page has no OG image, the application may use its fallback behavior.
 
-## Local tests fail with localhost DNS errors
+### Database migration fails
 
-- Environment DNS resolution issue (not app logic).
-- Retry in a standard shell/network environment.
+Confirm `SUPABASE_DATABASE_URL` points to the intended Supabase Postgres
+project and that the migration files and `migrations/postgres/meta/_journal.json`
+are present. Do not delete migration history to work around a mismatch; inspect
+the database migration history and reconcile it before retrying.
+
+### Local tests report localhost DNS errors
+
+This usually indicates a local environment DNS issue rather than application
+logic. Retry in a standard shell/network environment.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -62,8 +62,9 @@ Functions. The database and service credentials must remain server-side and
 must not be committed or placed in frontend source. Netlify Functions read
 runtime values through `Netlify.env`; Netlify supplies `CONTEXT` automatically.
 
-Use the names in [`.env.schema`](../.env.schema). Do not configure legacy
-database variables for the active deployment.
+Use the required variable names in [`.env.schema`](../.env.schema).
+`SENTRY_DSN` is a separate optional Netlify runtime setting. Do not configure
+legacy database variables for the active deployment.
 
 ## 3. Apply migrations before deploying code
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,130 +1,148 @@
 # Production Deployment
 
-Last updated: February 26, 2026
+Last updated: July 11, 2026
 
-## Overview
+MakerBench is deployed as a Vite static frontend and Netlify Functions backed
+by Supabase Postgres and Supabase Auth. Build settings are defined in
+`netlify.toml`.
 
-MakerBench is deployed as:
+Related runbooks:
 
-- Static frontend bundle (`dist`)
-- Netlify Functions (`netlify/functions`)
-- Turso as the primary database
+- Database details: [../DATABASE_SETUP.md](../DATABASE_SETUP.md)
+- Local development: [local-development.md](./local-development.md)
 
-Build config is defined in `netlify.toml`.
+## Runtime baseline
 
-Runtime and package manager baseline:
+- Node.js 24.x
+- pnpm 11.5.0, pinned by `package.json`
+- Netlify build command: `pnpm build`
+- Static publish directory: `dist`
+- Functions directory: `netlify/functions`
 
-- Node.js 24
-- pnpm
-- Bun is intentionally out of scope for production deployment in this project.
+Bun is not part of the production deployment workflow.
 
 ## Prerequisites
 
-- Netlify site connected to this repository
-- Turso production database created
-- Browserless API key
+- A Netlify site connected to this repository
+- A Supabase production project
+- Supabase Auth providers and redirect URLs configured for the production site
 - Cloudinary credentials
-- (Optional) Sentry DSN
+- A Browserless API key
+- An optional Sentry DSN
 
-## 1. Create/verify production database
+## 1. Configure Supabase Postgres and Auth
 
-Using Turso CLI:
+Use the production Supabase project and obtain its PostgreSQL connection string
+from the Supabase connection details. Use the pooler connection string for
+Netlify Functions when available.
 
-```bash
-turso auth login
-turso db create makerbench-prod
-turso db show --url makerbench-prod
-turso db tokens create makerbench-prod
-```
+Configure the Google and GitHub providers used by the application in Supabase
+Auth. Add the production Netlify site URL to Supabase's allowed redirect URLs.
+The application sends the current browser origin as the OAuth redirect URL.
 
-Save the URL/token securely for Netlify environment variables.
+See [Database setup](../DATABASE_SETUP.md) for the full Supabase and Auth
+setup, including the server-only connection string requirement.
 
 ## 2. Configure Netlify environment variables
 
-In Netlify site settings, add:
+In the Netlify site settings, set these variables for every production deploy
+context that needs them:
 
-- `TURSO_DATABASE_URL`
-- `TURSO_AUTH_TOKEN`
-- `BROWSERLESS_API_KEY`
+- `SUPABASE_DATABASE_URL` - server-only Supabase Postgres connection string
+- `VITE_SUPABASE_URL` - Supabase project URL
+- `VITE_SUPABASE_ANON_KEY` - Supabase anon key
 - `CLOUDINARY_CLOUD_NAME`
 - `CLOUDINARY_API_KEY`
 - `CLOUDINARY_API_SECRET`
+- `BROWSERLESS_API_KEY`
 - `SENTRY_DSN` (optional)
 
-Also ensure Netlify provides `CONTEXT` automatically (used by Sentry env tagging).
+The `VITE_` variables must be available during the frontend build and to the
+Functions. The database and service credentials must remain server-side and
+must not be committed or placed in frontend source. Netlify Functions read
+runtime values through `Netlify.env`; Netlify supplies `CONTEXT` automatically.
 
-## 3. Apply schema before deploying code
+Use the names in [`.env.schema`](../.env.schema). Do not configure legacy
+database variables for the active deployment.
 
-Important order of operations:
+## 3. Apply migrations before deploying code
 
-1. Apply DB schema changes
-2. Deploy code that depends on them
-
-From a trusted environment with production DB credentials:
-
-```bash
-npx drizzle-kit push
-```
-
-If schema changed:
+From a trusted environment with the production `SUPABASE_DATABASE_URL`
+available, apply the committed PostgreSQL migrations:
 
 ```bash
-npx drizzle-kit generate
-npx drizzle-kit push
+pnpm db:migrate
 ```
 
-## 4. Run pre-deploy quality gates
+For a schema change, generate the migration, review it, commit it, and apply
+it before deploying the dependent application code:
+
+```bash
+pnpm db:generate
+pnpm db:migrate
+```
+
+The migration files and `migrations/postgres/meta/_journal.json` must be
+included in the repository. Do not use `drizzle-kit push`, and do not make
+untracked dashboard changes that bypass the Drizzle migration history.
+
+## 4. Run pre-deploy checks
 
 ```bash
 pnpm lint
 pnpm lint:css
 pnpm typecheck
 pnpm test
-npx vitest --project storybook run   # optional; Storybook interaction tests
+npx vitest --project storybook run
 pnpm build
 ```
 
-Storybook itself is a dev/CI aid — `pnpm build-storybook` is not part of the Netlify production build unless you add a separate publish step.
+Storybook is a development and CI aid. `pnpm build-storybook` is not part of
+the Netlify production build unless a separate publish step is introduced.
 
 ## 5. Deploy
 
-Typical flow is Git-based deployment via Netlify:
+The normal flow is Git-based deployment:
 
-1. Push branch/merge to production branch
-2. Netlify runs `pnpm build`
-3. Netlify publishes `dist` and deploys functions from `netlify/functions`
+1. Merge or push the release commit to the branch connected to production.
+2. Netlify runs `pnpm build`.
+3. Netlify publishes `dist` and deploys Functions from `netlify/functions`.
 
-## 6. Post-deploy verification
+## 6. Verify the deployment
 
-1. Load homepage and `/submit`.
-2. Verify function endpoints:
-   - `GET /api/bookmarks`
-   - `GET /api/bookmarks/search?q=test`
-3. Submit a bookmark and confirm response `201`.
-4. Check function logs in Netlify for runtime errors.
-5. If Sentry enabled, verify events are received.
+1. Load the homepage and `/submit`.
+2. Test Supabase sign-in with a configured provider.
+3. Confirm `GET /api/tools` returns approved tools.
+4. Confirm `GET /api/tools/search?q=test` returns JSON.
+5. Submit a bookmark and confirm a `201` response.
+6. For an authenticated user, verify `/library` and its API requests.
+7. Check Netlify Function logs for runtime errors.
+8. If Sentry is configured, verify that events arrive in the expected project.
 
-## Routing note for SPA paths
+## SPA routing
 
-MakerBench uses client-side routing (`/submit`, `/about`, `/privacy`).
-If deep-link refreshes return 404 in production, add an SPA redirect rule in Netlify:
+`netlify.toml` already redirects all paths to `/index.html` with status `200`
+for client-side routes such as `/submit`, `/about`, and `/privacy`. If a
+production deep-link refresh returns `404`, verify that the deployed Netlify
+configuration includes this redirect:
 
 ```toml
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+from = "/*"
+to = "/index.html"
+status = 200
 ```
 
-## Rollback strategy
+## Rollback
 
-- Use Netlify deploy history to rollback to the previous successful deploy.
-- If rollback is due to schema mismatch, either:
-  - re-deploy matching app version, or
-  - apply forward-compatible schema changes before re-release.
+Use Netlify deploy history to restore the previous successful deploy. If the
+rollback is related to a schema mismatch, deploy the matching application
+version or apply a forward-compatible migration before releasing again.
 
-## Security and secrets
+## Security
 
-- Never commit `.env`.
-- Rotate Turso, Browserless, and Cloudinary secrets if exposed.
-- Keep `SENTRY_DSN` optional for non-production environments.
+- Never commit `.env` files, resolved `.env.schema` values, or database URLs.
+- Keep `SUPABASE_DATABASE_URL` server-only and use a pooler connection for
+  serverless workloads when available.
+- Rotate Supabase, Cloudinary, Browserless, and Sentry credentials if exposed.
+- Keep `SENTRY_DSN` optional in non-production environments.

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -4,7 +4,7 @@ import "./PrivacyPage.css";
  * Privacy policy page.
  */
 export function PrivacyPage() {
-  const lastUpdated = "March 6, 2026";
+  const lastUpdated = "July 11, 2026";
 
   return (
     <article className="PrivacyPage">
@@ -41,8 +41,8 @@ export function PrivacyPage() {
           </li>
         </ul>
         <p>
-          We do not provide a general user account system, and we do not ask for passwords or
-          payment details.
+          You may sign in with Google or GitHub through Supabase Auth. MakerBench does not ask you
+          to create a separate password or provide payment details.
         </p>
       </section>
 
@@ -92,8 +92,9 @@ export function PrivacyPage() {
             serverless functions.
           </li>
           <li>
-            <span className="PrivacyPage-emphasis">Turso:</span> database storage for bookmarks,
-            tags, and submission metadata.
+            <span className="PrivacyPage-emphasis">Supabase:</span> Postgres database storage for
+            bookmarks, tags, submission metadata, and user preferences, plus authentication for
+            Google and GitHub sign-in.
           </li>
           <li>
             <span className="PrivacyPage-emphasis">Browserless:</span> screenshot capture for


### PR DESCRIPTION
## Summary

- replace active Turso/libSQL setup instructions with Supabase Postgres and Supabase Auth
- document the current Drizzle migration workflow and schema-before-code deployment order
- align local and production environment names with `.env.schema`
- retain Turso only as historical import context

## Impact

New contributors and maintainers can follow the setup and deployment runbooks without provisioning the retired Turso backend or bypassing committed PostgreSQL migrations.

## Checks

- Prettier
- Markdown link validation
- stale Turso text audit
- `git diff --check`

Closes #131.
