### PR TITLE
test: verify moderated content on public surfaces

### DIFF
--- a/e2e/publication-surfaces.spec.ts
+++ b/e2e/publication-surfaces.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const approvedTool = {
+  id: "approved-tool",
+  url: "https://approved-tool.example.com",
+  title: "Approved Tool",
+  description: "A reviewed tool for public discovery.",
+  imageUrl: null,
+  submitterName: null,
+  submitterGithubUrl: null,
+  createdAt: "2026-07-11T08:00:00.000Z",
+  tags: [{ id: "reviewed", name: "reviewed" }],
+};
+
+const approvedResources = [
+  {
+    id: "approved-article",
+    url: "https://example.com/approved-article",
+    title: "Approved Article",
+    description: "Reviewed long-form guidance.",
+    tags: [{ id: "reading", name: "reading" }],
+    createdAt: "2026-07-11T10:00:00.000Z",
+    kind: "article",
+  },
+  {
+    id: "approved-resource",
+    url: "https://example.com/approved-resource",
+    title: "Approved Resource",
+    description: "A reviewed reference.",
+    tags: [{ id: "reference", name: "reference" }],
+    createdAt: "2026-07-11T09:00:00.000Z",
+    kind: "resource",
+  },
+  {
+    id: "approved-stack",
+    url: "https://example.com/approved-stack",
+    title: "Approved Stack",
+    description: "A reviewed collection.",
+    tags: [{ id: "collection", name: "collection" }],
+    createdAt: "2026-07-11T08:00:00.000Z",
+    kind: "stack",
+    children: [
+      {
+        id: "approved-child",
+        url: "https://example.com/approved-child",
+        title: "Approved Stack Child",
+        description: null,
+        tags: [],
+      },
+    ],
+  },
+];
+
+async function mockPublicTools(page: Page) {
+  await page.route(
+    (url) =>
+      ["/api/tools", "/api/tools/search", "/api/tools/tags"].includes(
+        url.pathname,
+      ),
+    async (route) => {
+      const path = new URL(route.request().url()).pathname;
+
+      if (path === "/api/tools/tags") {
+        await route.fulfill({ json: { success: true, data: { tags: [] } } });
+        return;
+      }
+
+      await route.fulfill({
+        json: {
+          success: true,
+          data: {
+            bookmarks: [approvedTool],
+            pagination: { total: null, limit: 20, offset: 0, hasMore: false },
+          },
+        },
+      });
+    },
+  );
+}
+
+async function mockPublicResources(page: Page) {
+  await page.route(
+    (url) => ["/api/resources", "/api/resources/search"].includes(url.pathname),
+    async (route) => {
+      await route.fulfill({
+        json: {
+          success: true,
+          data: {
+            resources: approvedResources,
+            pagination: { total: 3, limit: 20, offset: 0, hasMore: false },
+          },
+        },
+      });
+    },
+  );
+}
+
+test.describe("public publication surfaces", () => {
+  for (const route of ["/", "/tools"]) {
+    test(`renders approved tools on ${route}`, async ({ page }) => {
+      await mockPublicTools(page);
+      await page.goto(route);
+      await expect(page.getByRole("link", { name: "Approved Tool" })).toBeVisible();
+
+      await expect(page.locator(".ToolGrid")).toMatchAriaSnapshot(`
+        - article:
+          - link "Approved Tool":
+            - /url: https://approved-tool.example.com
+            - heading "Approved Tool" [level=3]
+            - paragraph: approved-tool.example.com
+            - paragraph: A reviewed tool for public discovery.
+          - button "reviewed"
+      `);
+      await expect(page.getByText(/Pending|Rejected/)).toHaveCount(0);
+    });
+  }
+
+  test("renders approved resource kinds and only approved stack children", async ({
+    page,
+  }) => {
+    await mockPublicResources(page);
+    await page.goto("/resources");
+    await page.getByText("1 resources in this stack").click();
+
+    await expect(page.locator(".ResourceGrid")).toMatchAriaSnapshot(`
+      - article:
+        - link "Approved Article":
+          - text: Article
+          - heading "Approved Article" [level=3]
+          - paragraph: example.com
+          - paragraph: Reviewed long-form guidance.
+        - button "reading"
+      - article:
+        - link "Approved Resource":
+          - text: Resource
+          - heading "Approved Resource" [level=3]
+          - paragraph: example.com
+          - paragraph: A reviewed reference.
+        - button "reference"
+      - article:
+        - link "Approved Stack":
+          - text: Stack
+          - heading "Approved Stack" [level=3]
+          - paragraph: example.com
+          - paragraph: A reviewed collection.
+        - button "collection"
+        - group:
+          - text: 1 resources in this stack
+          - list:
+            - listitem:
+              - link "Approved Stack Child"
+              - text: example.com
+    `);
+    await expect(page.getByText(/Pending|Rejected/)).toHaveCount(0);
+  });
+});

--- a/e2e/publication-surfaces.spec.ts
+++ b/e2e/publication-surfaces.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test, type Page } from "@playwright/test";
 
-const approvedTool = {
-  id: "approved-tool",
-  url: "https://approved-tool.example.com",
-  title: "Approved Tool",
-  description: "A reviewed tool for public discovery.",
+const approvedBrowseTool = {
+  id: "approved-browse-tool",
+  url: "https://approved-browse-tool.example.com",
+  title: "Approved Browse Tool",
+  description: "A reviewed tool returned by public browse.",
   imageUrl: null,
   submitterName: null,
   submitterGithubUrl: null,
@@ -12,7 +12,15 @@ const approvedTool = {
   tags: [{ id: "reviewed", name: "reviewed" }],
 };
 
-const approvedResources = [
+const approvedSearchTool = {
+  ...approvedBrowseTool,
+  id: "approved-search-tool",
+  url: "https://approved-search-tool.example.com",
+  title: "Approved Search Tool",
+  description: "A reviewed tool returned by public search.",
+};
+
+const approvedBrowseResources = [
   {
     id: "approved-article",
     url: "https://example.com/approved-article",
@@ -51,6 +59,16 @@ const approvedResources = [
   },
 ];
 
+const approvedSearchResource = {
+  id: "approved-search-article",
+  url: "https://example.com/approved-search-article",
+  title: "Approved Search Article",
+  description: "Reviewed guidance returned by resource search.",
+  tags: [{ id: "search", name: "search" }],
+  createdAt: "2026-07-11T11:00:00.000Z",
+  kind: "article",
+};
+
 async function mockPublicTools(page: Page) {
   await page.route(
     (url) =>
@@ -69,7 +87,11 @@ async function mockPublicTools(page: Page) {
         json: {
           success: true,
           data: {
-            bookmarks: [approvedTool],
+            bookmarks: [
+              path === "/api/tools/search"
+                ? approvedSearchTool
+                : approvedBrowseTool,
+            ],
             pagination: { total: null, limit: 20, offset: 0, hasMore: false },
           },
         },
@@ -82,12 +104,22 @@ async function mockPublicResources(page: Page) {
   await page.route(
     (url) => ["/api/resources", "/api/resources/search"].includes(url.pathname),
     async (route) => {
+      const path = new URL(route.request().url()).pathname;
+
       await route.fulfill({
         json: {
           success: true,
           data: {
-            resources: approvedResources,
-            pagination: { total: 3, limit: 20, offset: 0, hasMore: false },
+            resources:
+              path === "/api/resources/search"
+                ? [approvedSearchResource]
+                : approvedBrowseResources,
+            pagination: {
+              total: path === "/api/resources/search" ? 1 : 3,
+              limit: 20,
+              offset: 0,
+              hasMore: false,
+            },
           },
         },
       });
@@ -95,25 +127,51 @@ async function mockPublicResources(page: Page) {
   );
 }
 
+// These E2E cases prove that approved API responses render on each public route.
+// Function query tests own pending/rejected exclusion because public payloads omit status.
 test.describe("public publication surfaces", () => {
   for (const route of ["/", "/tools"]) {
     test(`renders approved tools on ${route}`, async ({ page }) => {
       await mockPublicTools(page);
       await page.goto(route);
-      await expect(page.getByRole("link", { name: "Approved Tool" })).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Approved Browse Tool" }),
+      ).toBeVisible();
 
       await expect(page.locator(".ToolGrid")).toMatchAriaSnapshot(`
         - article:
-          - link "Approved Tool":
-            - /url: https://approved-tool.example.com
-            - heading "Approved Tool" [level=3]
-            - paragraph: approved-tool.example.com
-            - paragraph: A reviewed tool for public discovery.
+          - link "Approved Browse Tool":
+            - /url: https://approved-browse-tool.example.com
+            - heading "Approved Browse Tool" [level=3]
+            - paragraph: approved-browse-tool.example.com
+            - paragraph: A reviewed tool returned by public browse.
           - button "reviewed"
       `);
-      await expect(page.getByText(/Pending|Rejected/)).toHaveCount(0);
     });
   }
+
+  test("renders approved tool search results from the search endpoint", async ({
+    page,
+  }) => {
+    await mockPublicTools(page);
+    await page.goto("/tools");
+    await page
+      .getByRole("searchbox", { name: "Search by title or tag" })
+      .fill("search");
+    await expect(
+      page.getByRole("link", { name: "Approved Search Tool" }),
+    ).toBeVisible();
+
+    await expect(page.locator(".ToolGrid")).toMatchAriaSnapshot(`
+      - article:
+        - link "Approved Search Tool":
+          - /url: https://approved-search-tool.example.com
+          - heading "Approved Search Tool" [level=3]
+          - paragraph: approved-search-tool.example.com
+          - paragraph: A reviewed tool returned by public search.
+        - button "reviewed"
+    `);
+  });
 
   test("renders approved resource kinds and only approved stack children", async ({
     page,
@@ -151,6 +209,28 @@ test.describe("public publication surfaces", () => {
               - link "Approved Stack Child"
               - text: example.com
     `);
-    await expect(page.getByText(/Pending|Rejected/)).toHaveCount(0);
+  });
+
+  test("renders approved resource search results from the search endpoint", async ({
+    page,
+  }) => {
+    await mockPublicResources(page);
+    await page.goto("/resources");
+    await page
+      .getByRole("searchbox", { name: "Search resources" })
+      .fill("search");
+    await expect(
+      page.getByRole("link", { name: "Approved Search Article" }),
+    ).toBeVisible();
+
+    await expect(page.locator(".ResourceGrid")).toMatchAriaSnapshot(`
+      - article:
+        - link "Approved Search Article":
+          - text: Article
+          - heading "Approved Search Article" [level=3]
+          - paragraph: example.com
+          - paragraph: Reviewed guidance returned by resource search.
+        - button "search"
+    `);
   });
 });

--- a/netlify/functions/__tests__/get-bookmarks.test.ts
+++ b/netlify/functions/__tests__/get-bookmarks.test.ts
@@ -30,6 +30,7 @@ vi.mock("../lib/db", () => ({
 
 import getBookmarks from "../get-bookmarks.mts";
 import { getDb } from "../lib/db";
+import { getPgQuery } from "./test-utils";
 
 function createMockContext(): Context {
   return {
@@ -173,6 +174,16 @@ describe("get-bookmarks", () => {
       expect(body.data.bookmarks[0].tags).toHaveLength(1);
       expect(body.data.pagination.total).toBeNull();
       expect(body.data.pagination.hasMore).toBe(true);
+    });
+
+    it("limits public browse results to approved tools", async () => {
+      mockDb.offset.mockResolvedValueOnce([]);
+
+      await getBookmarks(new Request("https://test.com/api/tools"), mockContext);
+
+      const query = getPgQuery(mockDb.where.mock.calls[0]?.[0]);
+      expect(query.sql).toContain('"tool_listings"."status" = $1');
+      expect(query.params).toEqual(["approved"]);
     });
 
     it("caps limit at MAX_LIMIT (100)", async () => {

--- a/netlify/functions/__tests__/get-resources.test.ts
+++ b/netlify/functions/__tests__/get-resources.test.ts
@@ -37,6 +37,7 @@ vi.mock("../lib/db", () => ({
 
 import getResources from "../get-resources.mts";
 import { getDb } from "../lib/db";
+import { getSqlText } from "./test-utils";
 
 function createMockContext(): Context {
   return {
@@ -129,6 +130,24 @@ describe("get-resources", () => {
             tags: ["automation"],
             status: "approved",
           },
+          {
+            id: "stack-item-pending",
+            public_stack_id: "stack-1",
+            url: "https://example.com/pending-child",
+            title: "Pending Child",
+            description: null,
+            tags: [],
+            status: "pending",
+          },
+          {
+            id: "stack-item-rejected",
+            public_stack_id: "stack-1",
+            url: "https://example.com/rejected-child",
+            title: "Rejected Child",
+            description: null,
+            tags: [],
+            status: "rejected",
+          },
         ],
       });
 
@@ -174,6 +193,15 @@ describe("get-resources", () => {
       hasMore: true,
     });
     expect(mockDb.execute).toHaveBeenCalledTimes(3);
+
+    const pageSql = getSqlText(mockDb.execute.mock.calls[0]?.[0]);
+    const countSql = getSqlText(mockDb.execute.mock.calls[1]?.[0]);
+    const childrenSql = getSqlText(mockDb.execute.mock.calls[2]?.[0]);
+    expect(pageSql).toContain("where public_listings.status = 'approved'");
+    expect(pageSql).toContain("where public_stacks.status = 'approved'");
+    expect(countSql).toContain("public_listings where status = 'approved'");
+    expect(countSql).toContain("public_stacks where status = 'approved'");
+    expect(childrenSql).toContain("and public_stack_items.status = 'approved'");
   });
 
   it("does not query stack items when the page contains no stacks", async () => {

--- a/netlify/functions/__tests__/get-resources.test.ts
+++ b/netlify/functions/__tests__/get-resources.test.ts
@@ -37,7 +37,7 @@ vi.mock("../lib/db", () => ({
 
 import getResources from "../get-resources.mts";
 import { getDb } from "../lib/db";
-import { getSqlText } from "./test-utils";
+import { getPgQuery } from "./test-utils";
 
 function createMockContext(): Context {
   return {
@@ -194,9 +194,9 @@ describe("get-resources", () => {
     });
     expect(mockDb.execute).toHaveBeenCalledTimes(3);
 
-    const pageSql = getSqlText(mockDb.execute.mock.calls[0]?.[0]);
-    const countSql = getSqlText(mockDb.execute.mock.calls[1]?.[0]);
-    const childrenSql = getSqlText(mockDb.execute.mock.calls[2]?.[0]);
+    const pageSql = getPgQuery(mockDb.execute.mock.calls[0]?.[0]).sql;
+    const countSql = getPgQuery(mockDb.execute.mock.calls[1]?.[0]).sql;
+    const childrenSql = getPgQuery(mockDb.execute.mock.calls[2]?.[0]).sql;
     expect(pageSql).toContain("where public_listings.status = 'approved'");
     expect(pageSql).toContain("where public_stacks.status = 'approved'");
     expect(countSql).toContain("public_listings where status = 'approved'");

--- a/netlify/functions/__tests__/search-bookmarks.test.ts
+++ b/netlify/functions/__tests__/search-bookmarks.test.ts
@@ -30,6 +30,7 @@ vi.mock("../lib/db", () => ({
 
 import searchBookmarks from "../search-bookmarks.mts";
 import { getDb } from "../lib/db";
+import { getPgQuery } from "./test-utils";
 
 function createMockContext(): Context {
   return {
@@ -194,6 +195,19 @@ describe("search-bookmarks", () => {
       const body = (await res.json()) as SuccessResponse<SearchResultsData>;
       expect(body.data.bookmarks).toHaveLength(1);
       expect(body.data.pagination.hasMore).toBe(false);
+    });
+
+    it("limits public search results to approved tools", async () => {
+      mockDb.offset.mockResolvedValueOnce([]);
+
+      await searchBookmarks(
+        new Request("https://test.com/api/tools/search?q=moderated"),
+        mockContext,
+      );
+
+      const query = getPgQuery(mockDb.where.mock.calls[0]?.[0]);
+      expect(query.sql).toContain('"tool_listings"."status" = $1');
+      expect(query.params[0]).toBe("approved");
     });
   });
 });

--- a/netlify/functions/__tests__/search-resources.test.ts
+++ b/netlify/functions/__tests__/search-resources.test.ts
@@ -37,7 +37,7 @@ vi.mock("../lib/db", () => ({
 
 import searchResources from "../search-resources.mts";
 import { getDb } from "../lib/db";
-import { getSqlText } from "./test-utils";
+import { getPgQuery } from "./test-utils";
 
 function createMockContext(): Context {
   return {
@@ -142,9 +142,9 @@ describe("search-resources", () => {
     });
     expect(mockDb.execute).toHaveBeenCalledTimes(3);
 
-    const pageSql = getSqlText(mockDb.execute.mock.calls[0]?.[0]);
-    const countSql = getSqlText(mockDb.execute.mock.calls[1]?.[0]);
-    const childrenSql = getSqlText(mockDb.execute.mock.calls[2]?.[0]);
+    const pageSql = getPgQuery(mockDb.execute.mock.calls[0]?.[0]).sql;
+    const countSql = getPgQuery(mockDb.execute.mock.calls[1]?.[0]).sql;
+    const childrenSql = getPgQuery(mockDb.execute.mock.calls[2]?.[0]).sql;
     expect(pageSql).toContain("where public_listings.status = 'approved'");
     expect(pageSql).toContain("where public_stacks.status = 'approved'");
     expect(countSql).toContain("where public_listings.status = 'approved'");

--- a/netlify/functions/__tests__/search-resources.test.ts
+++ b/netlify/functions/__tests__/search-resources.test.ts
@@ -37,6 +37,7 @@ vi.mock("../lib/db", () => ({
 
 import searchResources from "../search-resources.mts";
 import { getDb } from "../lib/db";
+import { getSqlText } from "./test-utils";
 
 function createMockContext(): Context {
   return {
@@ -140,6 +141,15 @@ describe("search-resources", () => {
       hasMore: true,
     });
     expect(mockDb.execute).toHaveBeenCalledTimes(3);
+
+    const pageSql = getSqlText(mockDb.execute.mock.calls[0]?.[0]);
+    const countSql = getSqlText(mockDb.execute.mock.calls[1]?.[0]);
+    const childrenSql = getSqlText(mockDb.execute.mock.calls[2]?.[0]);
+    expect(pageSql).toContain("where public_listings.status = 'approved'");
+    expect(pageSql).toContain("where public_stacks.status = 'approved'");
+    expect(countSql).toContain("where public_listings.status = 'approved'");
+    expect(countSql).toContain("where public_stacks.status = 'approved'");
+    expect(childrenSql).toContain("and public_stack_items.status = 'approved'");
   });
 
   it("does not hydrate non-approved stack item rows", async () => {

--- a/netlify/functions/__tests__/test-utils.ts
+++ b/netlify/functions/__tests__/test-utils.ts
@@ -35,16 +35,3 @@ export function createMockDb() {
 export function getPgQuery(query: unknown) {
   return pgDialect.sqlToQuery(query as SQL);
 }
-
-export function getSqlText(query: unknown): string {
-  if (!query || typeof query !== "object") {
-    return "";
-  }
-
-  if ("value" in query && Array.isArray(query.value)) {
-    return query.value.join("");
-  }
-
-  const queryChunks = (query as { queryChunks?: unknown[] }).queryChunks ?? [];
-  return queryChunks.map(getSqlText).join("");
-}

--- a/netlify/functions/__tests__/test-utils.ts
+++ b/netlify/functions/__tests__/test-utils.ts
@@ -1,5 +1,9 @@
 import type { Context } from "@netlify/functions";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { vi } from "vitest";
+
+const pgDialect = new PgDialect();
 
 export function createMockContext(): Context {
   return {
@@ -26,4 +30,21 @@ export function createMockDb() {
     limit: vi.fn().mockResolvedValue([]),
     orderBy: vi.fn().mockResolvedValue([]),
   };
+}
+
+export function getPgQuery(query: unknown) {
+  return pgDialect.sqlToQuery(query as SQL);
+}
+
+export function getSqlText(query: unknown): string {
+  if (!query || typeof query !== "object") {
+    return "";
+  }
+
+  if ("value" in query && Array.isArray(query.value)) {
+    return query.value.join("");
+  }
+
+  const queryChunks = (query as { queryChunks?: unknown[] }).queryChunks ?? [];
+  return queryChunks.map(getSqlText).join("");
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const playwrightPort = process.env.PLAYWRIGHT_PORT ?? "5173";
+const playwrightBaseUrl = `http://localhost:${playwrightPort}`;
+
 /**
  * Playwright configuration for MakerBench e2e and component testing.
  * @see https://playwright.dev/docs/test-configuration
@@ -13,7 +16,7 @@ export default defineConfig({
   reporter: "html",
 
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: playwrightBaseUrl,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
@@ -42,8 +45,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: "pnpm dev",
-    url: "http://localhost:5173",
+    command: `pnpm dev --port ${playwrightPort}`,
+    url: playwrightBaseUrl,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,26 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const playwrightPort = process.env.PLAYWRIGHT_PORT ?? "5173";
+const DEFAULT_PLAYWRIGHT_PORT = 5173;
+
+/** Parses the optional E2E server port into a safe TCP port number. */
+function parsePlaywrightPort(value: string | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_PLAYWRIGHT_PORT;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw new Error("PLAYWRIGHT_PORT must be an integer between 1 and 65535");
+  }
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("PLAYWRIGHT_PORT must be an integer between 1 and 65535");
+  }
+
+  return port;
+}
+
+const playwrightPort = parsePlaywrightPort(process.env.PLAYWRIGHT_PORT);
 const playwrightBaseUrl = `http://localhost:${playwrightPort}`;
 
 /**
@@ -45,7 +65,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: `pnpm dev --port ${playwrightPort}`,
+    command: `pnpm dev --port=${playwrightPort} --strictPort`,
     url: playwrightBaseUrl,
     reuseExistingServer: !process.env.CI,
   },

--- a/src/hooks/__tests__/useResources.test.tsx
+++ b/src/hooks/__tests__/useResources.test.tsx
@@ -1,0 +1,166 @@
+import { StrictMode, type ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api")>();
+  return {
+    ...actual,
+    getResources: vi.fn(),
+  };
+});
+
+import { getResources, type Resource, type ResourcesResponse } from "../../api";
+import { useResources } from "../useResources";
+
+const approvedResource: Resource = {
+  id: "resource-1",
+  url: "https://example.com/resource-1",
+  title: "Resource One",
+  description: "A public resource",
+  tags: [{ id: "reference", name: "reference" }],
+  createdAt: "2026-07-11T10:00:00.000Z",
+  kind: "resource",
+};
+
+const mockedGetResources = vi.mocked(getResources);
+
+function createResponse(resources: Resource[]): ResourcesResponse {
+  return {
+    resources,
+    pagination: {
+      total: resources.length,
+      limit: 20,
+      offset: 0,
+      hasMore: false,
+    },
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function StrictModeWrapper({ children }: { children: ReactNode }) {
+  return <StrictMode>{children}</StrictMode>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetResources.mockResolvedValue(createResponse([approvedResource]));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useResources", () => {
+  it("performs one successful initial fetch through Strict Mode replay", async () => {
+    const { result } = renderHook(() => useResources(), {
+      wrapper: StrictModeWrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.resources).toEqual([approvedResource]);
+    });
+
+    expect(mockedGetResources).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("does not start the queued initial fetch after unmount", () => {
+    const scheduledCallbacks: VoidFunction[] = [];
+    const queueMicrotaskSpy = vi
+      .spyOn(globalThis, "queueMicrotask")
+      .mockImplementation((callback) => {
+        scheduledCallbacks.push(callback);
+      });
+
+    const { unmount } = renderHook(() => useResources());
+    expect(scheduledCallbacks).toHaveLength(1);
+
+    unmount();
+    act(() => {
+      scheduledCallbacks[0]();
+    });
+
+    expect(mockedGetResources).not.toHaveBeenCalled();
+    queueMicrotaskSpy.mockRestore();
+  });
+
+  it("aborts an active initial request on unmount", async () => {
+    const pendingRequest = createDeferred<ResourcesResponse>();
+    let requestSignal: AbortSignal | undefined;
+    mockedGetResources.mockImplementation((_params, options) => {
+      requestSignal = options?.signal;
+      return pendingRequest.promise;
+    });
+
+    const { unmount } = renderHook(() => useResources());
+    await waitFor(() => {
+      expect(mockedGetResources).toHaveBeenCalledTimes(1);
+    });
+
+    expect(requestSignal?.aborted).toBe(false);
+    unmount();
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it("ignores an older response after a newer fetch starts", async () => {
+    const { result } = renderHook(() => useResources());
+    await waitFor(() => {
+      expect(result.current.resources).toEqual([approvedResource]);
+    });
+
+    const olderRequest = createDeferred<ResourcesResponse>();
+    const newerRequest = createDeferred<ResourcesResponse>();
+    let olderSignal: AbortSignal | undefined;
+    mockedGetResources
+      .mockImplementationOnce((_params, options) => {
+        olderSignal = options?.signal;
+        return olderRequest.promise;
+      })
+      .mockImplementationOnce(() => newerRequest.promise);
+
+    act(() => {
+      void result.current.fetch({ offset: 20 });
+    });
+    act(() => {
+      void result.current.fetch({ offset: 40 });
+    });
+
+    expect(olderSignal?.aborted).toBe(true);
+
+    const newerResource = {
+      ...approvedResource,
+      id: "resource-newer",
+      title: "Newer Resource",
+    };
+    await act(async () => {
+      newerRequest.resolve(createResponse([newerResource]));
+      await newerRequest.promise;
+    });
+
+    expect(result.current.resources).toEqual([newerResource]);
+
+    await act(async () => {
+      olderRequest.resolve(
+        createResponse([
+          {
+            ...approvedResource,
+            id: "resource-older",
+            title: "Older Resource",
+          },
+        ]),
+      );
+      await olderRequest.promise;
+    });
+
+    expect(result.current.resources).toEqual([newerResource]);
+  });
+});

--- a/src/hooks/useResources.ts
+++ b/src/hooks/useResources.ts
@@ -22,7 +22,6 @@ interface UseResourcesReturn extends UseResourcesState {
 }
 
 export function useResources(): UseResourcesReturn {
-  const hasFetched = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
   const activeRequestIdRef = useRef(0);
   const [state, setState] = useState<UseResourcesState>({
@@ -130,11 +129,16 @@ export function useResources(): UseResourcesReturn {
   }, [cancelActiveRequest]);
 
   useEffect(() => {
-    if (!hasFetched.current) {
-      hasFetched.current = true;
-      void fetch();
-    }
+    let isActive = true;
+
+    queueMicrotask(() => {
+      if (isActive) {
+        void fetch();
+      }
+    });
+
     return () => {
+      isActive = false;
       cancelActiveRequest();
     };
   }, [cancelActiveRequest, fetch]);


### PR DESCRIPTION
## Summary

- verify approved-only SQL predicates for tool and resource browse/search queries
- verify approved stacks hydrate only approved child items
- add route-level ARIA snapshot coverage for approved tools, resources, articles, stacks, and search results
- fix the `/resources` initial fetch under React Strict Mode and cover cancellation/race behavior
- make the Playwright port safely configurable for isolated E2E runs

## Impact

Moderation decisions now have regression coverage from the database-query boundary through the public routes. Pending and rejected rows are protected by function query tests; browser tests prove approved payloads reach the correct anonymous surfaces.

## Checks

- 29 focused unit/function tests passed
- 5 Chromium E2E cases passed
- typecheck passed
- focused ESLint passed
- independent review completed with no remaining findings

Closes #162.
