### PR TITLE
feat: add typed public submission client and hook

### DIFF
--- a/netlify/functions/__tests__/process-tool.test.ts
+++ b/netlify/functions/__tests__/process-tool.test.ts
@@ -215,8 +215,8 @@ describe("process-tool", () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
         body: JSON.stringify({
-          type: "article",
-          url: "https://example.com/article",
+          type: "resource",
+          url: "https://example.com/resource",
           tags: ["test"],
         }),
         headers: { "Content-Type": "application/json" },

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -37,7 +37,7 @@ import { createMockContext } from "./test-utils";
 
 interface SubmissionCreated {
   submittedItemId: string;
-  type: "tool" | "article" | "resource";
+  type: "tool" | "resource";
   status: "pending";
   message: string;
 }
@@ -88,7 +88,7 @@ describe("public-submissions", () => {
     });
   });
 
-  it("creates an anonymous pending article listing", async () => {
+  it("creates an anonymous pending resource listing", async () => {
     const mockDb = createMockDb();
     mockDb.returning
       .mockResolvedValueOnce([{ id: "11111111-1111-4111-8111-111111111111" }])
@@ -99,8 +99,8 @@ describe("public-submissions", () => {
 
     const res = await publicSubmissions(
       createSubmissionRequest({
-        type: "article",
-        url: "https://example.com/Article?b=2&a=1#section",
+        type: "resource",
+        url: "https://example.com/Resource?b=2&a=1#section",
         tags: ["React", " react ", "Testing"],
         submitterName: " Ada ",
         submitterGithubUsername: "ada-lovelace",
@@ -112,14 +112,14 @@ describe("public-submissions", () => {
     const body = (await res.json()) as SuccessResponse<SubmissionCreated>;
     expect(body.data).toMatchObject({
       submittedItemId: "22222222-2222-4222-8222-222222222222",
-      type: "article",
+      type: "resource",
       status: "pending",
     });
     expect(verifyAuthenticatedUser).not.toHaveBeenCalled();
     expect(mockDb.values).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        contentKind: "article",
+        contentKind: "resource",
         submittedByUserId: undefined,
         submitterName: "Ada",
         submitterGithubUrl: "https://github.com/ada-lovelace",
@@ -204,7 +204,7 @@ describe("public-submissions", () => {
   it("returns structured validation details", async () => {
     const res = await publicSubmissions(
       createSubmissionRequest({
-        type: "article",
+        type: "resource",
         url: "not-a-url",
         tags: [],
       }),
@@ -218,6 +218,20 @@ describe("public-submissions", () => {
     expect(body.details?.tags).toBeDefined();
   });
 
+  it("rejects article as a separate public submission type", async () => {
+    const res = await publicSubmissions(
+      createSubmissionRequest({
+        type: "article",
+        url: "https://example.com/article",
+        tags: ["writing"],
+      }),
+      createMockContext(),
+    );
+
+    expect(res.status).toBe(422);
+    expect(extractMetadata).not.toHaveBeenCalled();
+  });
+
   it("rejects hostnames that resolve to private addresses before metadata fetch", async () => {
     vi.mocked(lookup).mockResolvedValueOnce([
       { address: "10.0.0.12", family: 4 },
@@ -225,7 +239,7 @@ describe("public-submissions", () => {
 
     const res = await publicSubmissions(
       createSubmissionRequest({
-        type: "article",
+        type: "resource",
         url: "https://example.com/internal",
         tags: ["security"],
       }),

--- a/netlify/functions/lib/submissions.ts
+++ b/netlify/functions/lib/submissions.ts
@@ -330,7 +330,7 @@ async function createToolSubmission({
   return tool?.id ?? null;
 }
 
-/** Inserts a pending public article/resource listing linked to the shared resource row. */
+/** Inserts a pending public resource listing linked to the shared resource row. */
 async function createPublicListingSubmission({
   authenticated,
   metadata,
@@ -393,8 +393,7 @@ function getSuccessMessage(type: PublicSubmissionType): string {
     return "Tool submitted. It will be reviewed shortly.";
   }
 
-  const label = type === "article" ? "Article" : "Resource";
-  return `${label} submitted. It will be reviewed shortly.`;
+  return "Resource submitted. It will be reviewed shortly.";
 }
 
 /** Formats the generic processing error for the submitted content type. */

--- a/src/api/__tests__/bookmarks.test.ts
+++ b/src/api/__tests__/bookmarks.test.ts
@@ -132,10 +132,10 @@ function createGetTagsHandler() {
 }
 
 /**
- * Creates the POST /api/tools handler
+ * Creates the POST /api/submissions compatibility handler
  */
 function createSubmitBookmarkHandler() {
-  return http.post(`${API_BASE}/api/tools`, async ({ request }) => {
+  return http.post(`${API_BASE}/api/submissions`, async ({ request }) => {
     const body = (await request.json()) as { type?: string; url?: string; tags?: string[] };
 
     // Validate URL is present

--- a/src/api/__tests__/bookmarks.test.ts
+++ b/src/api/__tests__/bookmarks.test.ts
@@ -323,6 +323,39 @@ describe("submitBookmark", () => {
     expect(result.message).toContain("submitted");
   });
 
+  it("prefers a GitHub username over a conflicting profile URL", async () => {
+    let requestBody: unknown;
+    server.use(
+      http.post(`${API_BASE}/api/submissions`, async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json(
+          {
+            success: true,
+            data: {
+              submittedItemId: "11111111-1111-4111-8111-111111111111",
+              type: "tool",
+              status: "pending",
+              message: "Bookmark submitted. It will be reviewed shortly.",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await submitBookmark({
+      url: "https://example.com/new-tool",
+      tags: ["typescript"],
+      submitterGithubUsername: "preferred-user",
+      submitterGithubUrl: "https://github.com/ignored-user",
+    });
+
+    expect(requestBody).toMatchObject({
+      submitterGithubUrl: "https://github.com/preferred-user",
+    });
+    expect(requestBody).not.toHaveProperty("submitterGithubUsername");
+  });
+
   it("throws on validation error with details", async () => {
     try {
       await submitBookmark({

--- a/src/api/__tests__/submissions.test.ts
+++ b/src/api/__tests__/submissions.test.ts
@@ -1,0 +1,173 @@
+import { delay, http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { server } from "../../test/mocks/server";
+import {
+  PublicSubmissionApiError,
+  submitPublicSubmission,
+} from "../submissions";
+
+const API_BASE = "http://localhost:8888";
+const submittedItemId = "11111111-1111-4111-8111-111111111111";
+
+function createSubmissionHandler() {
+  return http.post(`${API_BASE}/api/submissions`, async ({ request }) => {
+    const body = (await request.json()) as { url?: string; type?: string };
+
+    if (!body.url) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: "Validation failed",
+          details: { url: ["URL is required"] },
+        },
+        { status: 422 },
+      );
+    }
+
+    if (body.url === "https://example.com/duplicate") {
+      return HttpResponse.json(
+        { success: false, error: "This URL has already been submitted" },
+        { status: 409 },
+      );
+    }
+
+    return HttpResponse.json(
+      {
+        success: true,
+        data: {
+          submittedItemId,
+          type: body.type,
+          status: "pending",
+          message: "Submission received for review.",
+        },
+      },
+      { status: 201 },
+    );
+  });
+}
+
+beforeEach(() => {
+  server.use(createSubmissionHandler());
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+describe("submitPublicSubmission", () => {
+  it("submits a resource and returns validated response data", async () => {
+    const result = await submitPublicSubmission({
+      type: "resource",
+      url: "https://example.com/reference",
+      tags: ["accessibility"],
+    });
+
+    expect(result).toEqual({
+      submittedItemId,
+      type: "resource",
+      status: "pending",
+      message: "Submission received for review.",
+    });
+  });
+
+  it("sends an access token when provided", async () => {
+    let authorization: string | null = null;
+    server.use(
+      http.post(`${API_BASE}/api/submissions`, ({ request }) => {
+        authorization = request.headers.get("Authorization");
+        return HttpResponse.json(
+          {
+            success: true,
+            data: {
+              submittedItemId,
+              type: "tool",
+              status: "pending",
+              message: "Tool submitted.",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await submitPublicSubmission(
+      { type: "tool", url: "https://example.com/tool", tags: ["testing"] },
+      { accessToken: "signed-in-token" },
+    );
+
+    expect(authorization).toBe("Bearer signed-in-token");
+  });
+
+  it("throws a typed validation error with structured details", async () => {
+    await expect(
+      submitPublicSubmission({ type: "resource", url: "", tags: ["testing"] }),
+    ).rejects.toMatchObject({
+      name: "PublicSubmissionApiError",
+      status: 422,
+      message: "Validation failed",
+      details: { url: ["URL is required"] },
+    });
+  });
+
+  it("throws a typed conflict error", async () => {
+    await expect(
+      submitPublicSubmission({
+        type: "tool",
+        url: "https://example.com/duplicate",
+        tags: ["testing"],
+      }),
+    ).rejects.toMatchObject({
+      name: "PublicSubmissionApiError",
+      status: 409,
+      message: "This URL has already been submitted",
+    });
+  });
+
+  it("rejects malformed success payloads with a typed error", async () => {
+    server.use(
+      http.post(`${API_BASE}/api/submissions`, () =>
+        HttpResponse.json(
+          { success: true, data: { type: "article" } },
+          { status: 201 },
+        ),
+      ),
+    );
+
+    const submission = submitPublicSubmission({
+      type: "resource",
+      url: "https://example.com/reference",
+      tags: ["testing"],
+    });
+
+    await expect(submission).rejects.toEqual(
+      expect.any(PublicSubmissionApiError),
+    );
+    await expect(submission).rejects.toMatchObject({
+      status: 500,
+      message: "Invalid response from server",
+    });
+  });
+
+  it("passes abort behavior through without wrapping it", async () => {
+    server.use(
+      http.post(`${API_BASE}/api/submissions`, async () => {
+        await delay("infinite");
+        return HttpResponse.json({});
+      }),
+    );
+    const controller = new AbortController();
+    const submission = submitPublicSubmission(
+      {
+        type: "tool",
+        url: "https://example.com/tool",
+        tags: ["testing"],
+      },
+      { signal: controller.signal },
+    );
+
+    controller.abort();
+
+    await expect(submission).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/src/api/bookmarks.ts
+++ b/src/api/bookmarks.ts
@@ -1,10 +1,10 @@
 import * as v from "valibot";
 import {
   apiErrorResponseSchema,
-  publicSubmissionResponseSchema,
   type BookmarkRequest,
   type PublicSubmissionResponseData,
 } from "../lib/validation";
+import { PublicSubmissionApiError, submitPublicSubmission } from "./submissions";
 
 function getBaseUrl(): string {
   if (typeof window !== "undefined") {
@@ -232,35 +232,15 @@ export async function getTags(
 }
 
 export async function submitBookmark(data: BookmarkRequest): Promise<SubmitBookmarkResponse> {
-  const { submitterGithubUsername, submitterGithubUrl, ...rest } = data;
-  const payload = {
-    ...rest,
-    type: "tool",
-    submitterGithubUrl: submitterGithubUsername
-      ? `https://github.com/${submitterGithubUsername}`
-      : submitterGithubUrl,
-  };
+  try {
+    return await submitPublicSubmission({ ...data, type: "tool" });
+  } catch (error) {
+    if (error instanceof PublicSubmissionApiError) {
+      throw new BookmarkApiError(error.message, error.status, error.details);
+    }
 
-  const response = await fetch(`${getBaseUrl()}/api/tools`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-  });
-
-  const json = await response.json();
-
-  if (!response.ok) {
-    throwApiError(json, response.status);
+    throw error;
   }
-
-  const result = v.safeParse(publicSubmissionResponseSchema, json);
-  if (!result.success) {
-    throw new BookmarkApiError("Invalid response from server", 500);
-  }
-
-  return result.output.data;
 }
 
 export const getTools = getBookmarks;

--- a/src/api/bookmarks.ts
+++ b/src/api/bookmarks.ts
@@ -232,8 +232,16 @@ export async function getTags(
 }
 
 export async function submitBookmark(data: BookmarkRequest): Promise<SubmitBookmarkResponse> {
+  const { submitterGithubUsername, submitterGithubUrl, ...submission } = data;
+
   try {
-    return await submitPublicSubmission({ ...data, type: "tool" });
+    return await submitPublicSubmission({
+      ...submission,
+      type: "tool",
+      submitterGithubUrl: submitterGithubUsername
+        ? `https://github.com/${submitterGithubUsername}`
+        : submitterGithubUrl,
+    });
   } catch (error) {
     if (error instanceof PublicSubmissionApiError) {
       throw new BookmarkApiError(error.message, error.status, error.details);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -42,3 +42,11 @@ export {
   type LibraryResponse,
   type LibraryTag,
 } from "./library";
+
+export {
+  submitPublicSubmission,
+  PublicSubmissionApiError,
+  type PublicSubmissionInput,
+  type PublicSubmissionOptions,
+  type PublicSubmissionResponse,
+} from "./submissions";

--- a/src/api/submissions.ts
+++ b/src/api/submissions.ts
@@ -1,0 +1,94 @@
+import * as v from "valibot";
+
+import {
+  apiErrorResponseSchema,
+  publicSubmissionResponseSchema,
+  type PublicSubmissionRequest,
+  type PublicSubmissionResponseData,
+} from "../lib/validation";
+
+function getBaseUrl(): string {
+  if (typeof window !== "undefined") {
+    return "";
+  }
+
+  return process.env.API_BASE_URL || "http://localhost:8888";
+}
+
+export interface PublicSubmissionOptions {
+  accessToken?: string;
+  signal?: AbortSignal;
+}
+
+export type PublicSubmissionInput = PublicSubmissionRequest;
+export type PublicSubmissionResponse = PublicSubmissionResponseData;
+
+export class PublicSubmissionApiError extends Error {
+  status: number;
+  details?: Record<string, string[]>;
+
+  constructor(
+    message: string,
+    status: number,
+    details?: Record<string, string[]>,
+  ) {
+    super(message);
+    this.name = "PublicSubmissionApiError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+function throwApiError(json: unknown, status: number): never {
+  const parsed = v.safeParse(apiErrorResponseSchema, json);
+  throw new PublicSubmissionApiError(
+    parsed.success ? parsed.output.error : "An unexpected error occurred",
+    status,
+    parsed.success ? parsed.output.details : undefined,
+  );
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw error;
+    }
+
+    throw new PublicSubmissionApiError("Invalid response from server", 500);
+  }
+}
+
+/** Submits a tool or resource to the public moderation queue. */
+export async function submitPublicSubmission(
+  data: PublicSubmissionInput,
+  options: PublicSubmissionOptions = {},
+): Promise<PublicSubmissionResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (options.accessToken) {
+    headers.Authorization = `Bearer ${options.accessToken}`;
+  }
+
+  const response = await fetch(`${getBaseUrl()}/api/submissions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(data),
+    signal: options.signal,
+  });
+  const json = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throwApiError(json, response.status);
+  }
+
+  const result = v.safeParse(publicSubmissionResponseSchema, json);
+  if (!result.success) {
+    throw new PublicSubmissionApiError("Invalid response from server", 500);
+  }
+
+  return result.output.data;
+}

--- a/src/components/__tests__/SubmitPage.test.tsx
+++ b/src/components/__tests__/SubmitPage.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { SubmitPage } from "../../pages/SubmitPage";
+import { server } from "../../test/mocks/server";
+
+describe("SubmitPage", () => {
+  it("submits the existing tool form through the public submission endpoint", async () => {
+    let requestBody: unknown;
+    server.use(
+      http.post("/api/submissions", async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json(
+          {
+            success: true,
+            data: {
+              submittedItemId: "11111111-1111-4111-8111-111111111111",
+              type: "tool",
+              status: "pending",
+              message: "Tool submitted.",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+    const user = userEvent.setup();
+    render(<SubmitPage />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: /tool url/i }),
+      "https://example.com/tool",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: /^tags/i }),
+      "testing{Enter}",
+    );
+    await user.click(screen.getByRole("button", { name: "Submit Tool" }));
+
+    expect(
+      await screen.findByText(/tool submitted successfully/i),
+    ).toBeInTheDocument();
+    expect(requestBody).toEqual({
+      type: "tool",
+      url: "https://example.com/tool",
+      tags: ["testing"],
+    });
+  });
+
+  it("renders structured server validation details", async () => {
+    server.use(
+      http.post("/api/submissions", () =>
+        HttpResponse.json(
+          {
+            success: false,
+            error: "Validation failed",
+            details: { url: ["This domain is blocked"] },
+          },
+          { status: 422 },
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+    render(<SubmitPage />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: /tool url/i }),
+      "https://example.com/tool",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: /^tags/i }),
+      "testing{Enter}",
+    );
+    await user.click(screen.getByRole("button", { name: "Submit Tool" }));
+
+    expect(await screen.findByText(/submission failed/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/url: this domain is blocked/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/usePublicSubmission.test.tsx
+++ b/src/hooks/__tests__/usePublicSubmission.test.tsx
@@ -106,4 +106,88 @@ describe("usePublicSubmission", () => {
     expect(result.current.error).toBeNull();
     expect(result.current.response).toBeNull();
   });
+
+  it("keeps the newer response when it supersedes an older delayed request", async () => {
+    let olderRequestStarted = false;
+    server.use(
+      http.post("/api/submissions", async ({ request }) => {
+        const body = (await request.json()) as { url: string; type: string };
+        const isOlderRequest = body.url.endsWith("/older");
+        if (isOlderRequest) {
+          olderRequestStarted = true;
+          await delay(100);
+        }
+
+        return HttpResponse.json(
+          {
+            success: true,
+            data: {
+              submittedItemId: isOlderRequest
+                ? "22222222-2222-4222-8222-222222222222"
+                : "33333333-3333-4333-8333-333333333333",
+              type: body.type,
+              status: "pending",
+              message: "Submission received for review.",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+    const { result } = renderHook(() => usePublicSubmission());
+    let olderSubmission!: Promise<unknown>;
+    let newerResponse!: Awaited<ReturnType<typeof result.current.submit>>;
+
+    act(() => {
+      olderSubmission = result.current.submit({
+        type: "resource",
+        url: "https://example.com/older",
+        tags: ["testing"],
+      });
+    });
+    await waitFor(() => expect(olderRequestStarted).toBe(true));
+
+    await act(async () => {
+      newerResponse = await result.current.submit({
+        type: "resource",
+        url: "https://example.com/newer",
+        tags: ["testing"],
+      });
+    });
+    await expect(olderSubmission).resolves.toBeNull();
+
+    expect(newerResponse?.submittedItemId).toBe("33333333-3333-4333-8333-333333333333");
+    expect(result.current.response).toEqual(newerResponse);
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("aborts on unmount without applying stale response or error state", async () => {
+    let requestSignal: AbortSignal | undefined;
+    server.use(
+      http.post("/api/submissions", async ({ request }) => {
+        requestSignal = request.signal;
+        await delay("infinite");
+        return HttpResponse.json({});
+      }),
+    );
+    const { result, unmount } = renderHook(() => usePublicSubmission());
+    let submission!: Promise<unknown>;
+
+    act(() => {
+      submission = result.current.submit({
+        type: "tool",
+        url: "https://example.com/tool",
+        tags: ["testing"],
+      });
+    });
+    await waitFor(() => expect(requestSignal).toBeDefined());
+
+    unmount();
+
+    await expect(submission).resolves.toBeNull();
+    expect(requestSignal?.aborted).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.response).toBeNull();
+  });
 });

--- a/src/hooks/__tests__/usePublicSubmission.test.tsx
+++ b/src/hooks/__tests__/usePublicSubmission.test.tsx
@@ -1,0 +1,109 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { delay, http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { PublicSubmissionApiError } from "../../api";
+import { server } from "../../test/mocks/server";
+import { usePublicSubmission } from "../usePublicSubmission";
+
+const submittedItemId = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => {
+  server.use(
+    http.post("/api/submissions", async ({ request }) => {
+      const body = (await request.json()) as { url?: string; type?: string };
+      if (!body.url) {
+        return HttpResponse.json(
+          {
+            success: false,
+            error: "Validation failed",
+            details: { url: ["URL is required"] },
+          },
+          { status: 422 },
+        );
+      }
+
+      return HttpResponse.json(
+        {
+          success: true,
+          data: {
+            submittedItemId,
+            type: body.type,
+            status: "pending",
+            message: "Submission received for review.",
+          },
+        },
+        { status: 201 },
+      );
+    }),
+  );
+});
+
+describe("usePublicSubmission", () => {
+  it("submits successfully and stores the response", async () => {
+    const { result } = renderHook(() => usePublicSubmission());
+
+    await act(async () => {
+      await result.current.submit({
+        type: "resource",
+        url: "https://example.com/reference",
+        tags: ["accessibility"],
+      });
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.response).toMatchObject({
+      submittedItemId,
+      type: "resource",
+      status: "pending",
+    });
+  });
+
+  it("stores typed validation errors and details", async () => {
+    const { result } = renderHook(() => usePublicSubmission());
+
+    await act(async () => {
+      await result.current.submit({ type: "tool", url: "", tags: ["testing"] });
+    });
+
+    expect(result.current.error).toBeInstanceOf(PublicSubmissionApiError);
+    expect(result.current.error).toMatchObject({
+      status: 422,
+      details: { url: ["URL is required"] },
+    });
+    expect(result.current.response).toBeNull();
+  });
+
+  it("aborts an active request when reset without surfacing an error", async () => {
+    server.use(
+      http.post("/api/submissions", async () => {
+        await delay("infinite");
+        return HttpResponse.json({});
+      }),
+    );
+    const { result } = renderHook(() => usePublicSubmission());
+    let submission!: Promise<unknown>;
+
+    act(() => {
+      submission = result.current.submit({
+        type: "tool",
+        url: "https://example.com/tool",
+        tags: ["testing"],
+      });
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    await act(async () => {
+      await submission;
+    });
+    await waitFor(() => expect(result.current.isSubmitting).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.response).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useSubmitBookmark.test.tsx
+++ b/src/hooks/__tests__/useSubmitBookmark.test.tsx
@@ -7,7 +7,7 @@ import { useSubmitBookmark } from "../useSubmitBookmark";
 import { BookmarkApiError } from "../../api";
 
 function createSubmitHandler() {
-  return http.post("/api/tools", async ({ request }) => {
+  return http.post("/api/submissions", async ({ request }) => {
     const body = (await request.json()) as { url?: string; tags?: string[] };
 
     if (!body.url) {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export { useBookmarks } from "./useBookmarks";
 export { useSearch } from "./useSearch";
 export { useSubmitBookmark } from "./useSubmitBookmark";
+export { usePublicSubmission } from "./usePublicSubmission";
 export { useTags } from "./useTags";
 export { useResources } from "./useResources";
 export { useResourceSearch } from "./useResourceSearch";

--- a/src/hooks/usePublicSubmission.ts
+++ b/src/hooks/usePublicSubmission.ts
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  PublicSubmissionApiError,
+  submitPublicSubmission,
+  type PublicSubmissionInput,
+  type PublicSubmissionOptions,
+  type PublicSubmissionResponse,
+} from "../api";
+
+interface UsePublicSubmissionState {
+  isSubmitting: boolean;
+  error: PublicSubmissionApiError | null;
+  response: PublicSubmissionResponse | null;
+}
+
+interface UsePublicSubmissionReturn extends UsePublicSubmissionState {
+  submit: (
+    data: PublicSubmissionInput,
+  ) => Promise<PublicSubmissionResponse | null>;
+  reset: () => void;
+}
+
+/** Manages public submission state and cancels stale requests. */
+export function usePublicSubmission(
+  options: Pick<PublicSubmissionOptions, "accessToken"> = {},
+): UsePublicSubmissionReturn {
+  const abortRef = useRef<AbortController | null>(null);
+  const activeRequestIdRef = useRef(0);
+  const [state, setState] = useState<UsePublicSubmissionState>({
+    isSubmitting: false,
+    error: null,
+    response: null,
+  });
+
+  async function submit(
+    data: PublicSubmissionInput,
+  ): Promise<PublicSubmissionResponse | null> {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    activeRequestIdRef.current += 1;
+    const requestId = activeRequestIdRef.current;
+
+    setState({ isSubmitting: true, error: null, response: null });
+
+    try {
+      const response = await submitPublicSubmission(data, {
+        accessToken: options.accessToken,
+        signal: controller.signal,
+      });
+      if (
+        controller.signal.aborted ||
+        requestId !== activeRequestIdRef.current
+      ) {
+        return null;
+      }
+
+      setState({ isSubmitting: false, error: null, response });
+      return response;
+    } catch (error) {
+      if (
+        controller.signal.aborted ||
+        requestId !== activeRequestIdRef.current
+      ) {
+        return null;
+      }
+
+      const submissionError =
+        error instanceof PublicSubmissionApiError
+          ? error
+          : new PublicSubmissionApiError("Submission failed", 500);
+      setState({ isSubmitting: false, error: submissionError, response: null });
+      return null;
+    }
+  }
+
+  function reset() {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    activeRequestIdRef.current += 1;
+    setState({ isSubmitting: false, error: null, response: null });
+  }
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  return { ...state, submit, reset };
+}

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -104,7 +104,7 @@ describe("Validation Schemas", () => {
   });
 
   describe("validatePublicSubmissionRequest", () => {
-    it.each(["tool", "article", "resource"] as const)(
+    it.each(["tool", "resource"] as const)(
       "should validate %s public submissions",
       (type) => {
         const result = validatePublicSubmissionRequest({
@@ -153,8 +153,8 @@ describe("Validation Schemas", () => {
 
     it("should validate optional authenticated user context", () => {
       const result = validatePublicSubmissionRequest({
-        type: "article",
-        url: "https://example.com/article",
+        type: "resource",
+        url: "https://example.com/resource",
         tags: ["writing"],
         authenticatedUser: {
           userId: "11111111-1111-4111-8111-111111111111",
@@ -169,6 +169,16 @@ describe("Validation Schemas", () => {
         type: "video",
         url: "https://example.com/video",
         tags: ["media"],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject article as a separate public submission type", () => {
+      const result = validatePublicSubmissionRequest({
+        type: "article",
+        url: "https://example.com/article",
+        tags: ["writing"],
       });
 
       expect(result.success).toBe(false);

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -66,7 +66,7 @@ const optionalGithubUsernameSchema = v.optional(
   ]),
 );
 
-export const publicSubmissionTypeSchema = v.picklist(["tool", "article", "resource"]);
+export const publicSubmissionTypeSchema = v.picklist(["tool", "resource"]);
 export const publicSubmissionStatusSchema = v.picklist(["pending", "approved", "rejected"]);
 
 export const publicSubmissionAuthenticatedUserSchema = v.object({

--- a/src/pages/SubmitPage.tsx
+++ b/src/pages/SubmitPage.tsx
@@ -5,7 +5,7 @@ import { Alert } from "../components/ui";
 import { TextInput } from "../components/ui";
 import { Button } from "../components/ui";
 import { TagInput } from "../components/forms";
-import { useSubmitBookmark } from "../hooks";
+import { usePublicSubmission } from "../hooks/usePublicSubmission";
 import { bookmarkRequestSchema, type BookmarkRequest } from "../lib/validation";
 
 import "./SubmitPage.css";
@@ -21,7 +21,7 @@ interface FormErrors {
  * Submit page - form for submitting new tools.
  */
 export function SubmitPage() {
-  const { submit, isSubmitting, error, response, reset } = useSubmitBookmark();
+  const { submit, isSubmitting, error, response, reset } = usePublicSubmission();
 
   // Form state
   const [url, setUrl] = useState("");
@@ -81,7 +81,7 @@ export function SubmitPage() {
       submitterGithubUsername: submitterGithubUsername.trim() || undefined,
     };
 
-    const result = await submit(data);
+    const result = await submit({ ...data, type: "tool" });
 
     if (result) {
       // Reset form on success


### PR DESCRIPTION
## Summary

- add a typed `/api/submissions` client with Valibot success validation and structured API errors
- add a cancellation-aware public submission hook with auth-token support
- route the existing tool form and legacy adapter through the unified endpoint
- align the public contract with the project goal's binary `tool | resource` model
- add client, hook, component, endpoint, compatibility, abort, and race tests

## Impact

Public submission UI code now uses one typed API boundary instead of ad hoc or tool-only fetch behavior. Legacy callers retain error types and GitHub-attribution precedence while the broader auth-aware form work remains scoped to #156.

## Checks

- 294 tests passed, 1 skipped
- typecheck passed
- ESLint passed with one existing generated MSW warning
- `git diff --check` passed
- independent review completed with no remaining findings

The unchanged `www.github.com` canonical-host assertion remains the only unrelated full-suite failure.

Closes #155.
