### PR TITLE
feat: add auth-aware Submit a Resource flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Runtime/package manager decision:
 
 Core functionality is implemented:
 
-- Submit a tool URL with tags (stored as `pending` until moderation exists)
+- Submit a tool or resource URL with tags for moderation (stored as `pending`)
 - Extract metadata (title/description/OG image)
 - Capture screenshot fallback with Browserless when OG image is missing
 - Store fallback screenshots in Cloudinary
@@ -89,7 +89,8 @@ Package manager note: this repository pins pnpm via `packageManager` in `package
 
 Public:
 
-- `POST /api/tools` — submit a tool (stored as `pending`)
+- `POST /api/submissions` — submit a tool or resource for moderation (stored as `pending`)
+- `POST /api/tools` — compatibility endpoint for tool-only submissions
 - `GET /api/tools` — list approved tools (paginated)
 - `GET /api/tools/search` — search/filter approved tools
 - `GET /api/tools/tags` — tag cloud with usage counts

--- a/architecture.md
+++ b/architecture.md
@@ -185,6 +185,7 @@ Shared utilities live in `netlify/functions/lib/`:
 
 | Method | Path                    | Function file          | Auth | Description                                |
 | ------ | ----------------------- | ---------------------- | ---- | ------------------------------------------ |
+| `POST` | `/api/submissions`      | `public-submissions.mts` | Optional | Submit a tool or resource for moderation |
 | `POST` | `/api/tools`            | `process-tool.mts`     | No   | Submit tool (stored as `pending`)          |
 | `GET`  | `/api/tools`            | `get-bookmarks.mts`    | No   | List approved tools (paginated)            |
 | `GET`  | `/api/tools/search`     | `search-bookmarks.mts` | No   | Search/filter approved tools               |
@@ -209,13 +210,13 @@ All responses follow a consistent envelope:
 
 Valibot schemas in `src/lib/validation.ts` define:
 
-- Shared public submissions for tools, articles, and resources (`publicSubmissionRequestSchema`, `publicSubmissionResponseSchema`)
+- Shared public submissions for tools and resources (`publicSubmissionRequestSchema`, `publicSubmissionResponseSchema`)
 - Tool submission (`toolSubmissionSchema`)
 - Personal library entries (`personalResourceRequestSchema`)
 - Tag constraints (1–10 tags, max 50 chars each)
 - URL normalization rules (HTTP/HTTPS only, max 2000 chars)
 
-Public submission success responses return a submitted item id, `tool | article | resource` type, moderation status, and message. Functions call `validate*()` helpers; the frontend reuses the same schemas for form validation.
+Public submission success responses return a submitted item id, `tool | resource` type, moderation status, and message. Articles, guides, references, and other non-tool links use the `resource` type. Functions call `validate*()` helpers; the frontend reuses the same schemas for form validation.
 
 ### External service integrations
 

--- a/architecture.md
+++ b/architecture.md
@@ -1,19 +1,19 @@
 # MakerBench Architecture
 
-Last updated: May 30, 2026
+Last updated: July 11, 2026
 
 This document is the canonical technical reference for how MakerBench is structured, how data flows through the system, and what is planned next.
 
 ## Purpose
 
-MakerBench is a curated bookmarking platform for developer and maker tools. Users can:
+MakerBench is a curated bookmarking platform for developer and maker tools and resources. Users can:
 
 - **Browse** approved tools on the homepage (`/` or `/tools`)
-- **Submit** new tools for moderation (`/submit`)
-- **Discover** community-curated public resources and stacks (`/resources`)
+- **Submit** tools or resources for moderation (`/submit`)
+- **Discover** approved public resources and stacks (`/resources`)
 - **Save** personal bookmarks to a private library when signed in (`/library`)
 
-The platform separates **public tool listings** (moderated, anonymous submission) from **personal bookmarks** (authenticated, private) and **public resources** (LinkStack-derived community content).
+The platform separates moderated **public tool listings** and **public resource listings** from authenticated, private **personal bookmarks**. Public submission does not require sign-in, but every submission requires attribution and remains pending until reviewed.
 
 ## System Context
 
@@ -84,7 +84,8 @@ makerbench-next/
 | `/`, `/tools` | `HomePage`      | Browse and search approved tools          |
 | `/resources`  | `ResourcesPage` | Browse and search public resources/stacks |
 | `/library`    | `LibraryPage`   | Authenticated personal bookmark library   |
-| `/submit`     | `SubmitPage`    | Submit a tool for moderation              |
+| `/submit`     | `SubmitPage`    | Submit a tool or resource for moderation  |
+| `/admin/moderation` | `AdminModerationPage` | Review pending public listings (admin) |
 | `/about`      | `AboutPage`     | About the project                         |
 | `/privacy`    | `PrivacyPage`   | Privacy policy                            |
 | `*`           | `NotFoundPage`  | 404                                       |
@@ -112,16 +113,19 @@ The project prefers **semantic HTML and web platform primitives**, with React us
 
 ### State and data fetching
 
-| Hook                  | Data source                               | Used by             |
-| --------------------- | ----------------------------------------- | ------------------- |
-| `useBookmarks`        | `GET /api/tools`                          | HomePage            |
-| `useSearch`           | `GET /api/tools/search`                   | HomePage            |
-| `useTags`             | `GET /api/tools/tags`                     | HomePage            |
-| `useResources`        | `GET /api/resources`                      | ResourcesPage       |
-| `useResourceSearch`   | `GET /api/resources/search`               | ResourcesPage       |
-| `useLibraryResources` | `GET /api/library`                        | LibraryPage         |
-| `useSubmitBookmark`   | `POST /api/tools`                         | SubmitPage          |
-| `useAuth`             | Supabase session + `GET /api/auth/whoami` | Header, LibraryPage |
+| Hook                      | Data source                               | Used by                        |
+| ------------------------- | ----------------------------------------- | ------------------------------ |
+| `useBookmarks`            | `GET /api/tools`                          | HomePage                       |
+| `useSearch`               | `GET /api/tools/search`                   | HomePage                       |
+| `useTags`                 | `GET /api/tools/tags`                     | HomePage                       |
+| `useResources`            | `GET /api/resources`                      | ResourcesPage                  |
+| `useResourceSearch`       | `GET /api/resources/search`               | ResourcesPage                  |
+| `useLibraryResources`     | `GET/POST /api/library`                   | LibraryPage                    |
+| `usePublicSubmission`     | `POST /api/submissions`                   | SubmitPage                     |
+| `useAdminModerationQueue` | `GET/PATCH /api/admin/moderation`         | AdminModerationPage            |
+| `useAuth`                 | Supabase session + `GET /api/auth/whoami` | Header, Library, Submit, Admin |
+
+`useSubmitBookmark` remains as a legacy tool-only hook but delegates to the shared submission client. The current public submission UI uses `usePublicSubmission` and the binary `/api/submissions` contract; `POST /api/tools` remains a server compatibility route.
 
 Filter state (search query, tags, sort) is synced to URL search params so views are shareable.
 
@@ -159,6 +163,8 @@ sequenceDiagram
 - Client: `@supabase/supabase-js` in `src/lib/supabase.ts`; `AuthProvider` in `src/hooks/AuthProvider.tsx`
 - Server: `verifyAuthenticatedUser()` in `netlify/functions/lib/auth.ts` validates Bearer tokens and loads admin role from `user_roles`
 - Protected endpoints: `POST /api/library`, `GET /api/library` (personal bookmarks)
+- Optional-auth endpoint: `POST /api/submissions` accepts no token or a Bearer token. An invalid supplied token is rejected rather than treated as anonymous.
+- Submission identity: `GET /api/auth/whoami` exposes only verified display-name and GitHub metadata. `SubmitPage` waits for this lookup before deciding which attribution inputs are missing.
 
 ## Backend Architecture
 
@@ -183,18 +189,19 @@ Shared utilities live in `netlify/functions/lib/`:
 
 ### API surface
 
-| Method | Path                    | Function file          | Auth | Description                                |
-| ------ | ----------------------- | ---------------------- | ---- | ------------------------------------------ |
-| `POST` | `/api/submissions`      | `public-submissions.mts` | Optional | Submit a tool or resource for moderation |
-| `POST` | `/api/tools`            | `process-tool.mts`     | No   | Submit tool (stored as `pending`)          |
-| `GET`  | `/api/tools`            | `get-bookmarks.mts`    | No   | List approved tools (paginated)            |
-| `GET`  | `/api/tools/search`     | `search-bookmarks.mts` | No   | Search/filter approved tools               |
-| `GET`  | `/api/tools/tags`       | `get-tags.mts`         | No   | Tag cloud with usage counts                |
-| `GET`  | `/api/resources`        | `get-resources.mts`    | No   | List approved public resources/stacks      |
-| `GET`  | `/api/resources/search` | `search-resources.mts` | No   | Search public resources/stacks             |
-| `GET`  | `/api/library`          | `get-library.mts`      | Yes  | List user's personal bookmarks             |
-| `POST` | `/api/library`          | `add-library.mts`      | Yes  | Add URL to personal library                |
-| `GET`  | `/api/auth/whoami`      | `auth-whoami.mts`      | Yes  | Return authenticated identity + admin flag |
+| Method      | Path                    | Function file            | Auth            | Description                                    |
+| ----------- | ----------------------- | ------------------------ | --------------- | ---------------------------------------------- |
+| `POST`      | `/api/submissions`      | `public-submissions.mts` | Optional Bearer | Submit a tool or resource as `pending`         |
+| `POST`      | `/api/tools`            | `process-tool.mts`       | Optional Bearer | Legacy compatibility route; accepts tools only |
+| `GET`       | `/api/tools`            | `get-bookmarks.mts`      | No              | List approved tools (paginated)                |
+| `GET`       | `/api/tools/search`     | `search-bookmarks.mts`   | No              | Search/filter approved tools                   |
+| `GET`       | `/api/tools/tags`       | `get-tags.mts`           | No              | Tag cloud with usage counts                    |
+| `GET`       | `/api/resources`        | `get-resources.mts`      | No              | List approved public resources/stacks          |
+| `GET`       | `/api/resources/search` | `search-resources.mts`   | No              | Search public resources/stacks                 |
+| `GET`       | `/api/library`          | `get-library.mts`        | Bearer          | List user's personal bookmarks                 |
+| `POST`      | `/api/library`          | `add-library.mts`        | Bearer          | Add a URL to the personal library              |
+| `GET`       | `/api/auth/whoami`      | `auth-whoami.mts`        | Bearer          | Return verified identity and admin flag        |
+| `GET/PATCH` | `/api/admin/moderation` | `admin-moderation.mts`   | Admin Bearer    | List or review pending moderation items        |
 
 All responses follow a consistent envelope:
 
@@ -211,12 +218,16 @@ All responses follow a consistent envelope:
 Valibot schemas in `src/lib/validation.ts` define:
 
 - Shared public submissions for tools and resources (`publicSubmissionRequestSchema`, `publicSubmissionResponseSchema`)
-- Tool submission (`toolSubmissionSchema`)
+- Legacy tool compatibility submission (`toolSubmissionSchema`)
 - Personal library entries (`personalResourceRequestSchema`)
 - Tag constraints (1–10 tags, max 50 chars each)
 - URL normalization rules (HTTP/HTTPS only, max 2000 chars)
 
-Public submission success responses return a submitted item id, `tool | resource` type, moderation status, and message. Articles, guides, references, and other non-tool links use the `resource` type. Functions call `validate*()` helpers; the frontend reuses the same schemas for form validation.
+Public submission requests use a required binary `tool | resource` type. Articles, guides, references, and other non-tool links use `resource`; there is no third article API type. Anonymous requests must provide a name and GitHub username/profile URL. Authenticated requests may omit values already available from verified identity.
+
+The server always resolves attribution authoritatively. Verified display-name and GitHub identity take precedence over form values; a missing verified field may fall back to the corresponding submitted field. The request is rejected with structured validation details unless both resolved values are present. Success responses return the submitted listing id, type, `pending` status, and message.
+
+Functions call `validate*()` helpers, and the frontend reuses the shared schemas for form validation. Client validation improves feedback but does not replace server enforcement.
 
 ### External service integrations
 
@@ -278,10 +289,24 @@ erDiagram
     tool_listings {
         uuid id PK
         uuid resource_id FK
+        uuid submitted_by_user_id FK
         text status "pending|approved|rejected"
         text[] tags
         text image_url
         text image_source "og|screenshot|fallback"
+        text submitter_name
+        text submitter_github_url
+    }
+
+    public_listings {
+        uuid id PK
+        uuid resource_id FK
+        uuid submitted_by_user_id FK
+        text content_kind "resource"
+        text status "pending|approved|rejected"
+        text[] tags
+        text submitter_name
+        text submitter_github_url
     }
 
     bookmarks {
@@ -299,52 +324,64 @@ erDiagram
 | `resources`          | Canonical URL identity shared across all listing types           |
 | `tool_listings`      | Public tool submissions with moderation status and preview image |
 | `bookmarks`          | Per-user personal bookmarks (private library)                    |
-| `public_listings`    | Approved community resources (LinkStack migration)               |
+| `public_listings`    | Moderated resource submissions and migrated community resources  |
 | `public_stacks`      | Curated multi-item resource stacks                               |
 | `public_stack_items` | Items within a public stack                                      |
 | `user_roles`         | Admin role assignments                                           |
 | `user_preferences`   | User settings (e.g. highlight color)                             |
 | `auth.users`         | Supabase-managed auth users (referenced, not owned)              |
 
-**Status workflow:** Submissions across `tool_listings`, `public_listings`, `public_stacks`, and `public_stack_items` use `pending | approved | rejected`. Public endpoints return only `approved` rows. A unified admin moderation queue is not yet implemented — see [#105](https://github.com/schalkneethling/makerbench-next/issues/105).
+**Status workflow:** Submissions across `tool_listings`, `public_listings`, `public_stacks`, and `public_stack_items` use `pending | approved | rejected`. New public submissions always start as `pending`; public browse/search endpoints return only `approved` rows. Admins review pending items through `/admin/moderation` and `GET/PATCH /api/admin/moderation`.
 
 Search indexes use PostgreSQL GIN + `pg_trgm` on concatenated title, description, and tags for public resources.
 
 ## Key Flows
 
-### Submit a tool
+### Submit a public tool or resource
 
 ```mermaid
 sequenceDiagram
     participant Browser as Browser
-    participant API as POST /api/tools
+    participant Auth as Supabase Auth
+    participant API as POST /api/submissions
     participant Site as Target Site
     participant Shot as Browserless
     participant Img as Cloudinary
     participant DB as Postgres
 
-    Browser->>API: { url, tags, optional submitter }
-    API->>API: Validate (Valibot), normalize URL
+    Browser->>Auth: Resolve optional signed-in session
+    Auth-->>Browser: Verified identity or anonymous state
+    Browser->>API: Optional Bearer + { type: tool|resource, url, tags, missing attribution }
+    API->>API: Verify supplied token and validate (Valibot)
+    API->>API: Prefer verified identity, then form attribution; require name + GitHub
+    API->>API: Normalize URL and tags
     API->>Site: Fetch HTML for metadata
     Site-->>API: HTML
     API->>API: Extract title, description, og:image
+    API->>DB: Upsert canonical resource
 
-    alt OG image exists
-        API->>DB: Insert resource + tool_listing (pending, imageSource=og)
-    else No OG image
-        API->>Shot: Capture screenshot
-        alt Screenshot success
-            Shot-->>API: Image bytes
-            API->>Img: Upload
-            Img-->>API: Hosted URL
-            API->>DB: Insert (pending, imageSource=screenshot)
-        else Screenshot failed
-            API->>DB: Insert (pending, imageSource=fallback)
+    alt type is tool
+        alt OG image exists
+            API->>DB: Insert tool_listings row (pending, imageSource=og)
+        else No OG image
+            API->>Shot: Capture screenshot
+            alt Screenshot success
+                Shot-->>API: Image bytes
+                API->>Img: Upload
+                Img-->>API: Hosted URL
+                API->>DB: Insert tool_listings row (pending, imageSource=screenshot)
+            else Screenshot failed
+                API->>DB: Insert tool_listings row (pending, imageSource=fallback)
+            end
         end
+    else type is resource
+        API->>DB: Insert public_listings row (pending, contentKind=resource)
     end
 
-    API-->>Browser: 201 { bookmarkId }
+    API-->>Browser: 201 { submittedItemId, type, status: pending }
 ```
+
+`POST /api/tools` calls the same shared submission handler with an allowlist that accepts only `tool`. It is retained for compatibility; the current `SubmitPage` and `usePublicSubmission` use `/api/submissions`.
 
 ### Browse and search tools
 
@@ -444,37 +481,37 @@ Server-side functions read secrets via `Netlify.env.get()`. Client-visible vars 
 
 ## Current Gaps and Roadmap
 
-| Area                      | Status                                                                                                                                                                  |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Tool submission pipeline  | Implemented (`pending` status)                                                                                                                                          |
-| Public browse/search      | Implemented                                                                                                                                                             |
-| Personal library (auth)   | Implemented                                                                                                                                                             |
-| Public resources/stacks   | Implemented                                                                                                                                                             |
-| Moderation API + admin UI | **Not implemented** — unified queue needed for tools, public resources, stacks, and stack items ([#105](https://github.com/schalkneethling/makerbench-next/issues/105)) |
-| Algolia search            | Planned post-MVP                                                                                                                                                        |
+| Area                       | Status                                                                                                             |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Public submission pipeline | Implemented for binary `tool | resource` routing with required attribution and `pending` status                    |
+| Public browse/search       | Implemented                                                                                                        |
+| Personal library (auth)    | Implemented                                                                                                        |
+| Public resources/stacks    | Implemented                                                                                                        |
+| Moderation API + admin UI  | Implemented for tools, public resources, stacks, and stack items                                                   |
+| Algolia search             | Planned post-MVP                                                                                                   |
 
 See [ROADMAP.md](./ROADMAP.md) and [GitHub Issues](https://github.com/schalkneethling/makerbench-next/issues) for active backlog.
 
 ## Source Pointers
 
-| Concern              | Location                                                                     |
-| -------------------- | ---------------------------------------------------------------------------- |
-| Routes               | `src/App.tsx`                                                                |
-| Tool browse/search   | `src/pages/HomePage.tsx`                                                     |
-| Tool submission      | `src/pages/SubmitPage.tsx`                                                   |
-| Personal library     | `src/pages/LibraryPage.tsx`                                                  |
-| Public resources     | `src/pages/ResourcesPage.tsx`                                                |
-| API clients          | `src/api/`                                                                   |
-| Validation schemas   | `src/lib/validation.ts`                                                      |
-| Database schema      | `src/db/schema.ts`                                                           |
-| Submit handler       | `netlify/functions/process-tool.mts`                                         |
-| List/search handlers | `netlify/functions/get-bookmarks.mts`, `search-bookmarks.mts`                |
-| Auth handler         | `netlify/functions/auth-whoami.mts`                                          |
-| Library handlers     | `netlify/functions/get-library.mts`, `add-library.mts`                       |
-| Function shared libs | `netlify/functions/lib/`                                                     |
-| Migrations           | `migrations/postgres/`                                                       |
-| Storybook config     | `.storybook/main.ts`, `.storybook/preview.tsx`, `.storybook/msw-handlers.ts` |
-| Component stories    | `src/components/**/*.stories.tsx`                                            |
+| Concern              | Location                                                                                  |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| Routes               | `src/App.tsx`                                                                             |
+| Tool browse/search   | `src/pages/HomePage.tsx`                                                                  |
+| Public submission    | `src/pages/SubmitPage.tsx`, `src/hooks/usePublicSubmission.ts`                            |
+| Personal library     | `src/pages/LibraryPage.tsx`                                                               |
+| Public resources     | `src/pages/ResourcesPage.tsx`                                                             |
+| API clients          | `src/api/`                                                                                |
+| Validation schemas   | `src/lib/validation.ts`                                                                   |
+| Database schema      | `src/db/schema.ts`                                                                        |
+| Submit handlers      | `netlify/functions/public-submissions.mts`, `process-tool.mts`, `lib/submissions.ts`       |
+| List/search handlers | `netlify/functions/get-bookmarks.mts`, `search-bookmarks.mts`                             |
+| Auth handler         | `netlify/functions/auth-whoami.mts`                                                       |
+| Library handlers     | `netlify/functions/get-library.mts`, `add-library.mts`                                    |
+| Function shared libs | `netlify/functions/lib/`                                                                  |
+| Migrations           | `migrations/postgres/`                                                                    |
+| Storybook config     | `.storybook/main.ts`, `.storybook/preview.tsx`, `.storybook/msw-handlers.ts`              |
+| Component stories    | `src/components/**/*.stories.tsx`                                                         |
 
 ## Related Documentation
 

--- a/architecture.md
+++ b/architecture.md
@@ -302,7 +302,7 @@ erDiagram
         uuid id PK
         uuid resource_id FK
         uuid submitted_by_user_id FK
-        text content_kind "resource"
+        text content_kind "article|resource"
         text status "pending|approved|rejected"
         text[] tags
         text submitter_name
@@ -330,6 +330,8 @@ erDiagram
 | `user_roles`         | Admin role assignments                                           |
 | `user_preferences`   | User settings (e.g. highlight color)                             |
 | `auth.users`         | Supabase-managed auth users (referenced, not owned)              |
+
+`public_listings.content_kind` retains `article | resource` for migrated and existing rows. New public submission input is binary `tool | resource`; articles, guides, and other article-like links are submitted as `resource`, not as a third input type.
 
 **Status workflow:** Submissions across `tool_listings`, `public_listings`, `public_stacks`, and `public_stack_items` use `pending | approved | rejected`. New public submissions always start as `pending`; public browse/search endpoints return only `approved` rows. Admins review pending items through `/admin/moderation` and `GET/PATCH /api/admin/moderation`.
 

--- a/e2e/about-page.spec.ts
+++ b/e2e/about-page.spec.ts
@@ -7,32 +7,29 @@ test.describe("AboutPage", () => {
     await expect(page.locator("article.AboutPage")).toMatchAriaSnapshot(`
       - article:
         - heading "About MakerBench" [level=1]
-        - heading "Our Mission" [level=2]
-        - paragraph: MakerBench is a curated directory of tools and resources for makers, developers, and creators. We help you discover the right tools to bring your ideas to life, whether you're building a side project, launching a startup, or exploring new technologies.
-        - heading "What We Do" [level=2]
-        - paragraph: "We collect and organize tools across categories like development, design, productivity, marketing, and more. Each tool in our directory includes:"
-        - list:
-          - listitem: A clear description of what the tool does
-          - listitem: Relevant tags to help you find related tools
-          - listitem: Screenshots to see the tool in action
-          - listitem: Direct links to try or learn more
-        - heading "Community-Driven" [level=2]
-        - paragraph: MakerBench is built by makers, for makers. Anyone can submit a tool to the directory. We review each submission to ensure quality and relevance before adding it to the catalog.
+        - heading "What MakerBench Is" [level=2]
+        - paragraph: MakerBench is a curated directory of tools and resources for makers, developers, and teams building products on the web. The goal is simple: make useful links easier to discover without turning the site into a noisy list of everything on the internet.
+        - heading "How It Works" [level=2]
+        - paragraph: Tools and resources can be submitted by the community and are reviewed before they appear in the catalog. Each approved listing includes the metadata we can reliably collect, relevant tags, and an image when available so visitors can quickly evaluate whether it is worth exploring.
+        - heading "Contributing Resources" [level=2]
         - paragraph:
-          - text: Have a tool you love? Share it with the community by
-          - link "submitting it here":
+          - text: If you know a tool, article, guide, reference, or other resource that belongs here, use the
+          - link "submission form":
             - /url: /submit
-          - text: .
-        - heading "Open Source" [level=2]
+          - text: . Choose whether it is a tool or resource, then add its URL and a small set of accurate tags.
+        - paragraph: Submissions are reviewed before publication so the directory stays useful, consistent, and focused.
+        - heading "Contributing Code" [level=2]
         - paragraph:
-          - text: MakerBench is open source and built in the open. We believe in transparency and welcome contributions from the community. You can view the source code, report issues, or contribute improvements on
+          - text: MakerBench is open source. If you want to fix a bug, improve the UI, or tighten the docs, open an issue or pull request on
           - link "GitHub":
             - /url: https://github.com/schalkneethling/makerbench-next
-          - text: .
+          - text: . Small, focused contributions are preferred.
+        - heading "Project Scope" [level=2]
+        - paragraph: MakerBench is intentionally opinionated. The aim is not exhaustive coverage. The aim is a clean, searchable catalogue that helps people find high-signal tools quickly.
         - heading "Contact" [level=2]
         - paragraph:
-          - text: Questions or feedback? Reach out on GitHub at
-          - link "our project repository":
+          - text: Questions, corrections, or feedback can be shared in
+          - link "the project repository":
             - /url: https://github.com/schalkneethling/makerbench-next
           - text: .
     `);
@@ -47,7 +44,7 @@ test.describe("AboutPage", () => {
 
   test("submit link in content navigates correctly", async ({ page }) => {
     await page.goto("/about");
-    await page.getByRole("link", { name: "submitting it here" }).click();
+    await page.getByRole("link", { name: "submission form" }).click();
     await expect(page).toHaveURL("/submit");
   });
 

--- a/e2e/header.spec.ts
+++ b/e2e/header.spec.ts
@@ -12,7 +12,7 @@ test.describe("Header", () => {
         - link "Maker Bench":
           - /url: /
         - navigation "Primary":
-          - link "Submit Tool":
+          - link "Submit Resource":
             - /url: /submit
     `);
   });

--- a/e2e/main-layout.spec.ts
+++ b/e2e/main-layout.spec.ts
@@ -13,7 +13,7 @@ test.describe("MainLayout", () => {
       - banner:
         - link "Maker Bench"
         - navigation "Primary":
-          - link "Submit Tool"
+          - link "Submit Resource"
       - main
       - contentinfo:
         - paragraph: /© \\d{4} MakerBench/

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -7,9 +7,9 @@ test.describe("Navigation", () => {
     await expect(page).toHaveURL("/");
   });
 
-  test("Submit Tool link navigates to submit page", async ({ page }) => {
+  test("Submit Resource link navigates to submit page", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("link", { name: "Submit Tool" }).click();
+    await page.getByRole("link", { name: "Submit Resource" }).click();
     await expect(page).toHaveURL("/submit");
   });
 
@@ -34,6 +34,6 @@ test.describe("Route content", () => {
 
   test("submit page has correct heading", async ({ page }) => {
     await page.goto("/submit");
-    await expect(page.getByRole("heading", { level: 1 })).toHaveText("Submit a Tool");
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText("Submit a Resource");
   });
 });

--- a/e2e/submit-page.spec.ts
+++ b/e2e/submit-page.spec.ts
@@ -3,29 +3,31 @@ import { test, expect } from "@playwright/test";
 test.describe("SubmitPage", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/submit");
+    await expect(page.getByRole("button", { name: "Submit Resource" })).toBeEnabled();
   });
 
   test("has an accessible resource submission form", async ({ page }) => {
     await expect(page.locator(".SubmitPage")).toMatchAriaSnapshot(`
       - heading "Submit a Resource" [level=1]
       - paragraph: Share a useful tool or resource with the community for review.
-      - group "What are you submitting?":
-        - radio "Tool"
-        - text: Tool A developer or maker tool.
-        - radio "Resource"
-        - text: Resource An article, guide, reference, or other useful link.
-      - group "Submission details":
-        - text: URL * The main URL for the submission
-        - textbox "URL"
-        - text: Tags * Add 1-10 tags. Use commas or press Enter between tags.
-        - textbox "Tags"
-        - text: 0/10 tags
-      - group "Your details":
-        - text: Your name * Used to credit your submission
-        - textbox "Your name"
-        - text: GitHub username * Used to link your attribution to your GitHub profile
-        - textbox "GitHub username"
-      - button "Submit Resource"
+      - form "Submit a Resource":
+        - group "What are you submitting?":
+          - radio "Tool"
+          - text: Tool A developer or maker tool.
+          - radio "Resource"
+          - text: Resource An article, guide, reference, or other useful link.
+        - group "Submission details":
+          - text: URL * The main URL for the submission
+          - textbox "URL"
+          - text: Tags * Add 1-10 tags. Use commas or press Enter between tags.
+          - textbox "Tags"
+          - text: 0/10 tags
+        - group "Your details":
+          - text: Your name * Used to credit your submission
+          - textbox "Your name"
+          - text: GitHub username * Used to link your attribution to your GitHub profile
+          - textbox "GitHub username"
+        - button "Submit Resource"
     `);
   });
 

--- a/e2e/submit-page.spec.ts
+++ b/e2e/submit-page.spec.ts
@@ -5,109 +5,88 @@ test.describe("SubmitPage", () => {
     await page.goto("/submit");
   });
 
-  test("has correct page structure", async ({ page }) => {
-    // Page has heading and description
-    await expect(page.getByRole("heading", { level: 1 })).toHaveText("Submit a Tool");
-    await expect(page.getByText("Share a useful tool or resource")).toBeVisible();
+  test("has an accessible resource submission form", async ({ page }) => {
+    await expect(page.locator(".SubmitPage")).toMatchAriaSnapshot(`
+      - heading "Submit a Resource" [level=1]
+      - paragraph: Share a useful tool or resource with the community for review.
+      - group "What are you submitting?":
+        - radio "Tool"
+        - text: Tool A developer or maker tool.
+        - radio "Resource"
+        - text: Resource An article, guide, reference, or other useful link.
+      - group "Submission details":
+        - text: URL * The main URL for the submission
+        - textbox "URL"
+        - text: Tags * Add 1-10 tags. Use commas or press Enter between tags.
+        - textbox "Tags"
+        - text: 0/10 tags
+      - group "Your details":
+        - text: Your name * Used to credit your submission
+        - textbox "Your name"
+        - text: GitHub username * Used to link your attribution to your GitHub profile
+        - textbox "GitHub username"
+      - button "Submit Resource"
+    `);
   });
 
-  test("has accessible form with required fields", async ({ page }) => {
-    // URL input has correct label and is required
-    const urlInput = page.getByRole("textbox", { name: /tool url/i });
-    await expect(urlInput).toBeVisible();
-    await expect(urlInput).toHaveAttribute("type", "url");
+  test("requires a tool or resource selection and signed-out attribution", async ({ page }) => {
+    await expect(page.getByRole("radio", { name: "Tool" })).not.toBeChecked();
+    await expect(page.getByRole("radio", { name: "Resource" })).not.toBeChecked();
+    await expect(page.getByRole("radio", { name: /article/i })).toHaveCount(0);
+    await expect(page.getByRole("textbox", { name: "Your name" })).toHaveAttribute(
+      "aria-required",
+      "true",
+    );
+    await expect(page.getByRole("textbox", { name: "GitHub username" })).toHaveAttribute(
+      "aria-required",
+      "true",
+    );
 
-    // Tags input has correct label
-    const tagsContainer = page.locator(".TagInput");
-    await expect(tagsContainer).toBeVisible();
-    await expect(page.getByText(/tags/i).first()).toBeVisible();
+    await page.getByRole("button", { name: "Submit Resource" }).click();
 
-    // Submit button is present
-    await expect(page.getByRole("button", { name: /submit tool/i })).toBeVisible();
+    await expect(page.getByText("Please select a content type")).toBeVisible();
+    await expect(page.getByText("Your name is required")).toBeVisible();
+    await expect(page.getByText("GitHub username is required")).toBeVisible();
   });
 
-  test("has optional submitter fields", async ({ page }) => {
-    // Optional name field
-    const nameInput = page.getByRole("textbox", { name: /your name/i });
-    await expect(nameInput).toBeVisible();
+  test("switches between the binary submission types", async ({ page }) => {
+    const tool = page.getByRole("radio", { name: "Tool" });
+    const resource = page.getByRole("radio", { name: "Resource" });
+    const url = page.getByRole("textbox", { name: "URL" });
 
-    // Optional GitHub username field
-    const githubInput = page.getByRole("textbox", { name: /github username/i });
-    await expect(githubInput).toBeVisible();
+    await tool.check();
+    await expect(tool).toBeChecked();
+    await expect(resource).not.toBeChecked();
+    await expect(url).toHaveAttribute("placeholder", "https://example.com/tool");
+
+    await resource.check();
+    await expect(resource).toBeChecked();
+    await expect(tool).not.toBeChecked();
+    await expect(url).toHaveAttribute("placeholder", "https://example.com/resource");
   });
 
-  test("shows validation errors for empty required fields", async ({ page }) => {
-    // Submit without filling required fields
-    await page.getByRole("button", { name: /submit tool/i }).click();
-
-    // Should show URL error
-    await expect(page.getByText(/url is required/i)).toBeVisible();
-
-    // Should show tags error
-    await expect(page.getByText(/at least one tag is required/i)).toBeVisible();
-  });
-
-  test("shows validation error for invalid URL", async ({ page }) => {
-    // Enter invalid URL
-    await page.getByRole("textbox", { name: /tool url/i }).fill("not-a-url");
-
-    // Add a tag so tags don't error
-    await page.getByRole("textbox", { name: /tags/i }).fill("test");
+  test("shows validation errors for invalid submission details", async ({ page }) => {
+    await page.getByRole("radio", { name: "Resource" }).check();
+    await page.getByRole("textbox", { name: "URL" }).fill("not-a-url");
+    await page.getByRole("textbox", { name: "Tags" }).fill("test");
     await page.keyboard.press("Enter");
+    await page.getByRole("button", { name: "Submit Resource" }).click();
 
-    // Submit
-    await page.getByRole("button", { name: /submit tool/i }).click();
-
-    // Should show URL validation error
     await expect(page.getByText(/please enter a valid url/i)).toBeVisible();
   });
 
   test("can add and remove tags", async ({ page }) => {
-    const tagInput = page.getByRole("textbox", { name: /tags/i });
+    const tagInput = page.getByRole("textbox", { name: "Tags" });
 
-    // Add first tag
     await tagInput.fill("javascript");
     await page.keyboard.press("Enter");
-
-    // Tag should appear (use exact match to avoid matching "Remove javascript")
     await expect(page.locator(".TagInput-tagLabel", { hasText: "javascript" })).toBeVisible();
 
-    // Add second tag with comma
     await tagInput.fill("react,");
-
-    // Tag should appear
     await expect(page.locator(".TagInput-tagLabel", { hasText: "react" })).toBeVisible();
-
-    // Tag count should show 2/10
     await expect(page.getByText("2/10 tags")).toBeVisible();
 
-    // Remove first tag
     await page.getByRole("button", { name: /remove javascript/i }).click();
-
-    // Tag count should show 1/10
     await expect(page.getByText("1/10 tags")).toBeVisible();
-  });
-
-  test("displays correct fieldset legends", async ({ page }) => {
-    // Optional section has visible legend
-    await expect(page.getByText("Your Details (Optional)")).toBeVisible();
-  });
-
-  test("disables form while submitting", async ({ page }) => {
-    // Fill required fields
-    await page.getByRole("textbox", { name: /tool url/i }).fill("https://example.com");
-    await page.getByRole("textbox", { name: /tags/i }).fill("test");
-    await page.keyboard.press("Enter");
-
-    // Click submit - form should disable briefly
-    // Note: Without API mocking, this will fail quickly
-    // This test verifies the loading state appears
-    const submitButton = page.getByRole("button", { name: /submit/i });
-    await submitButton.click();
-
-    // Button should show loading state (text changes to "Submitting…")
-    // This may flash quickly if the API call fails fast
-    // We just verify the button exists and was clickable
-    await expect(submitButton).toBeVisible();
   });
 });

--- a/netlify/functions/__tests__/auth-whoami.test.ts
+++ b/netlify/functions/__tests__/auth-whoami.test.ts
@@ -54,10 +54,16 @@ describe("auth-whoami", () => {
               email: "test@example.com",
               user_metadata: {
                 full_name: "Test User",
-                user_name: "test-user",
+                user_name: "spoofed-user",
                 avatar_url: "https://example.com/avatar.png",
               },
               app_metadata: { provider: "github" },
+              identities: [
+                {
+                  provider: "github",
+                  identity_data: { user_name: "test-user" },
+                },
+              ],
             },
           },
           error: null,
@@ -116,7 +122,7 @@ describe("auth-whoami", () => {
     expect(body.data.isAdmin).toBe(false);
   });
 
-  it("does not expose a username from a non-GitHub provider", async () => {
+  it("does not expose user-editable GitHub metadata without a trusted identity", async () => {
     const mockDb = createMockDb();
     vi.mocked(getDb).mockReturnValue(mockDb as unknown as ReturnType<typeof getDb>);
     vi.mocked(createClient).mockReturnValue({
@@ -126,8 +132,9 @@ describe("auth-whoami", () => {
             user: {
               id: "user-1",
               email: "test@example.com",
-              user_metadata: { user_name: "not-github" },
-              app_metadata: { provider: "google" },
+              user_metadata: { user_name: "spoofed-user" },
+              app_metadata: { provider: "github" },
+              identities: [],
             },
           },
           error: null,

--- a/netlify/functions/__tests__/auth-whoami.test.ts
+++ b/netlify/functions/__tests__/auth-whoami.test.ts
@@ -19,6 +19,7 @@ interface WhoamiBody {
       id: string;
       email: string | null;
       displayName: string | null;
+      githubUsername: string | null;
       avatarUrl: string | null;
     };
     isAdmin: boolean;
@@ -53,8 +54,10 @@ describe("auth-whoami", () => {
               email: "test@example.com",
               user_metadata: {
                 full_name: "Test User",
+                user_name: "test-user",
                 avatar_url: "https://example.com/avatar.png",
               },
+              app_metadata: { provider: "github" },
             },
           },
           error: null,
@@ -76,6 +79,7 @@ describe("auth-whoami", () => {
         id: "user-1",
         email: "test@example.com",
         displayName: "Test User",
+        githubUsername: "test-user",
         avatarUrl: "https://example.com/avatar.png",
       },
       isAdmin: true,
@@ -110,5 +114,35 @@ describe("auth-whoami", () => {
 
     const body = (await res.json()) as WhoamiBody;
     expect(body.data.isAdmin).toBe(false);
+  });
+
+  it("does not expose a username from a non-GitHub provider", async () => {
+    const mockDb = createMockDb();
+    vi.mocked(getDb).mockReturnValue(mockDb as unknown as ReturnType<typeof getDb>);
+    vi.mocked(createClient).mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: "user-1",
+              email: "test@example.com",
+              user_metadata: { user_name: "not-github" },
+              app_metadata: { provider: "google" },
+            },
+          },
+          error: null,
+        }),
+      },
+    } as never);
+
+    const res = await authWhoami(
+      new Request("https://test.com/api/auth/whoami", {
+        headers: { Authorization: "Bearer token-1" },
+      }),
+      createMockContext(),
+    );
+
+    const body = (await res.json()) as WhoamiBody;
+    expect(body.data.user.githubUsername).toBeNull();
   });
 });

--- a/netlify/functions/__tests__/process-tool.test.ts
+++ b/netlify/functions/__tests__/process-tool.test.ts
@@ -90,6 +90,11 @@ function createMockDb() {
   return mockDb;
 }
 
+const anonymousAttribution = {
+  submitterName: "Ada Lovelace",
+  submitterGithubUsername: "ada-lovelace",
+};
+
 describe("process-tool", () => {
   let mockDb: ReturnType<typeof createMockDb>;
   let mockContext: Context;
@@ -178,6 +183,27 @@ describe("process-tool", () => {
       expect(body.details?.tags).toBeDefined();
     });
 
+    it("requires anonymous attribution with structured field errors", async () => {
+      const req = new Request("https://test.com/api/tools", {
+        method: "POST",
+        body: JSON.stringify({
+          type: "tool",
+          url: "https://example.com/tool",
+          tags: ["test"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const res = await processTool(req, mockContext);
+
+      expect(res.status).toBe(422);
+      const body = (await res.json()) as ErrorResponse;
+      expect(body.details).toEqual({
+        submitterName: ["Your name is required"],
+        submitterGithubUsername: ["GitHub username is required"],
+      });
+    });
+
     it("returns 422 for invalid URL format", async () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
@@ -185,6 +211,7 @@ describe("process-tool", () => {
           type: "tool",
           url: "not-a-url",
           tags: ["test"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -201,6 +228,7 @@ describe("process-tool", () => {
           type: "tool",
           url: "http://127.0.0.1:3000/tool",
           tags: ["test"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -218,6 +246,7 @@ describe("process-tool", () => {
           type: "resource",
           url: "https://example.com/resource",
           tags: ["test"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -244,6 +273,7 @@ describe("process-tool", () => {
             type: "tool",
             url: "https://example.com/tool",
             tags: ["test"],
+            ...anonymousAttribution,
           }),
           headers: { "Content-Type": "application/json" },
         });
@@ -274,6 +304,7 @@ describe("process-tool", () => {
           type: "tool",
           url: "https://example.com",
           tags: ["test"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -294,6 +325,7 @@ describe("process-tool", () => {
           type: "tool",
           url: "https://example.com/tool",
           tags: ["javascript", "testing"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -307,6 +339,14 @@ describe("process-tool", () => {
       expect(body.data.type).toBe("tool");
       expect(body.data.status).toBe("pending");
       expect(body.data.message).toContain("submitted");
+      expect(mockDb.values).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          submittedByUserId: undefined,
+          submitterName: "Ada Lovelace",
+          submitterGithubUrl: "https://github.com/ada-lovelace",
+        }),
+      );
     });
 
     it("extracts metadata from the URL", async () => {
@@ -316,6 +356,7 @@ describe("process-tool", () => {
           type: "tool",
           url: "https://example.com/tool",
           tags: ["test"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -338,6 +379,7 @@ describe("process-tool", () => {
           type: "tool",
           url: "https://example.com/tool",
           tags: ["test"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -370,6 +412,7 @@ describe("process-tool", () => {
           type: "tool",
           url: "https://example.com/tool",
           tags: ["test"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -403,6 +446,7 @@ describe("process-tool", () => {
           type: "tool",
           url: "https://example.com/tool",
           tags: ["test"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -420,6 +464,7 @@ describe("process-tool", () => {
           type: "tool",
           url: "https://example.com/tool",
           tags: ["JavaScript", "TESTING"],
+          ...anonymousAttribution,
         }),
         headers: { "Content-Type": "application/json" },
       });

--- a/netlify/functions/__tests__/process-tool.test.ts
+++ b/netlify/functions/__tests__/process-tool.test.ts
@@ -15,6 +15,14 @@ vi.mock("../lib/db", () => ({
   getDb: vi.fn(),
 }));
 
+vi.mock("../lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/auth")>();
+  return {
+    ...actual,
+    verifyAuthenticatedUser: vi.fn(),
+  };
+});
+
 // Mock external services
 vi.mock("../../../src/lib/services/metadata", () => ({
   extractMetadata: vi.fn(),
@@ -33,6 +41,7 @@ vi.mock("node:dns/promises", () => ({
 }));
 
 import processTool from "../process-tool.mts";
+import { verifyAuthenticatedUser } from "../lib/auth";
 import { getDb } from "../lib/db";
 import { lookup } from "node:dns/promises";
 import { extractMetadata } from "../../../src/lib/services/metadata";
@@ -105,6 +114,7 @@ describe("process-tool", () => {
     vi.mocked(getDb).mockReturnValue(
       mockDb as unknown as ReturnType<typeof getDb>,
     );
+    vi.mocked(verifyAuthenticatedUser).mockResolvedValue(null);
     mockContext = createMockContext();
     vi.mocked(lookup).mockResolvedValue([
       { address: "93.184.216.34", family: 4 },
@@ -202,6 +212,29 @@ describe("process-tool", () => {
         submitterName: ["Your name is required"],
         submitterGithubUsername: ["GitHub username is required"],
       });
+    });
+
+    it("rejects a forged authenticated user object", async () => {
+      const req = new Request("https://test.com/api/tools", {
+        method: "POST",
+        body: JSON.stringify({
+          type: "tool",
+          url: "https://example.com/tool",
+          tags: ["test"],
+          ...anonymousAttribution,
+          authenticatedUser: {
+            userId: "00000000-0000-4000-8000-000000000000",
+          },
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const res = await processTool(req, mockContext);
+
+      expect(res.status).toBe(422);
+      const body = (await res.json()) as ErrorResponse;
+      expect(body.details?.authenticatedUser).toBeDefined();
+      expect(verifyAuthenticatedUser).not.toHaveBeenCalled();
     });
 
     it("returns 422 for invalid URL format", async () => {
@@ -318,6 +351,49 @@ describe("process-tool", () => {
   });
 
   describe("successful submission", () => {
+    it("stores verified signed-in attribution instead of submitted spoofing", async () => {
+      vi.mocked(verifyAuthenticatedUser).mockResolvedValue({
+        user: {
+          id: "55555555-5555-4555-8555-555555555555",
+          user_metadata: { full_name: "Verified User" },
+          identities: [
+            {
+              provider: "github",
+              identity_data: { user_name: "verified-user" },
+            },
+          ],
+        },
+        isAdmin: false,
+      } as never);
+      const req = new Request("https://test.com/api/tools", {
+        method: "POST",
+        body: JSON.stringify({
+          type: "tool",
+          url: "https://example.com/signed-in-tool",
+          tags: ["testing"],
+          submitterName: "Spoofed Name",
+          submitterGithubUsername: "spoofed-user",
+        }),
+        headers: {
+          Authorization: "Bearer valid-token",
+          "Content-Type": "application/json",
+        },
+      });
+
+      const res = await processTool(req, mockContext);
+
+      expect(res.status).toBe(201);
+      expect(verifyAuthenticatedUser).toHaveBeenCalledOnce();
+      expect(mockDb.values).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          submittedByUserId: "55555555-5555-4555-8555-555555555555",
+          submitterName: "Verified User",
+          submitterGithubUrl: "https://github.com/verified-user",
+        }),
+      );
+    });
+
     it("returns 201 with public submission status data on success", async () => {
       const req = new Request("https://test.com/api/tools", {
         method: "POST",

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -2,9 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ErrorResponse, SuccessResponse } from "../lib/responses";
 
-vi.mock("../lib/auth", () => ({
-  verifyAuthenticatedUser: vi.fn(),
-}));
+vi.mock("../lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/auth")>();
+  return {
+    ...actual,
+    verifyAuthenticatedUser: vi.fn(),
+  };
+});
 
 vi.mock("../lib/db", () => ({
   getDb: vi.fn(),
@@ -194,6 +198,8 @@ describe("public-submissions", () => {
           type: "resource",
           url: "https://example.com/resource",
           tags: ["css"],
+          submitterName: "Spoofed Name",
+          submitterGithubUsername: "spoofed-user",
         },
         "valid-token",
       ),

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -128,6 +128,44 @@ describe("public-submissions", () => {
     );
   });
 
+  it("requires anonymous attribution with structured field errors", async () => {
+    const res = await publicSubmissions(
+      createSubmissionRequest({
+        type: "resource",
+        url: "https://example.com/resource",
+        tags: ["css"],
+      }),
+      createMockContext(),
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as ErrorResponse;
+    expect(body.details).toEqual({
+      submitterName: ["Your name is required"],
+      submitterGithubUsername: ["GitHub username is required"],
+    });
+  });
+
+  it("rejects a client-supplied authenticated user object", async () => {
+    const res = await publicSubmissions(
+      createSubmissionRequest({
+        type: "resource",
+        url: "https://example.com/resource",
+        tags: ["css"],
+        submitterName: "Ada",
+        submitterGithubUsername: "ada",
+        authenticatedUser: {
+          userId: "00000000-0000-4000-8000-000000000000",
+        },
+      }),
+      createMockContext(),
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as ErrorResponse;
+    expect(body.details?.authenticatedUser).toBeDefined();
+  });
+
   it("stores signed-in attribution for public resource listings", async () => {
     const mockDb = createMockDb();
     mockDb.returning
@@ -137,7 +175,16 @@ describe("public-submissions", () => {
       mockDb as unknown as ReturnType<typeof getDb>,
     );
     vi.mocked(verifyAuthenticatedUser).mockResolvedValue({
-      user: { id: "55555555-5555-4555-8555-555555555555" },
+      user: {
+        id: "55555555-5555-4555-8555-555555555555",
+        user_metadata: { full_name: "Verified User" },
+        identities: [
+          {
+            provider: "github",
+            identity_data: { user_name: "verified-user" },
+          },
+        ],
+      },
       isAdmin: false,
     } as never);
 
@@ -160,8 +207,40 @@ describe("public-submissions", () => {
       expect.objectContaining({
         contentKind: "resource",
         submittedByUserId: "55555555-5555-4555-8555-555555555555",
+        submitterName: "Verified User",
+        submitterGithubUrl: "https://github.com/verified-user",
       }),
     );
+  });
+
+  it("requires signed-in users to supply attribution the verified user cannot resolve", async () => {
+    vi.mocked(verifyAuthenticatedUser).mockResolvedValue({
+      user: {
+        id: "55555555-5555-4555-8555-555555555555",
+        user_metadata: {},
+        identities: [],
+      },
+      isAdmin: false,
+    } as never);
+
+    const res = await publicSubmissions(
+      createSubmissionRequest(
+        {
+          type: "resource",
+          url: "https://example.com/resource",
+          tags: ["css"],
+        },
+        "valid-token",
+      ),
+      createMockContext(),
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as ErrorResponse;
+    expect(body.details).toEqual({
+      submitterName: ["Your name is required"],
+      submitterGithubUsername: ["GitHub username is required"],
+    });
   });
 
   it("routes tool submissions to tool listings", async () => {
@@ -183,6 +262,8 @@ describe("public-submissions", () => {
         type: "tool",
         url: "https://example.com/tool",
         tags: ["ai"],
+        submitterName: "Ada",
+        submitterGithubUsername: "ada",
       }),
       createMockContext(),
     );
@@ -264,6 +345,8 @@ describe("public-submissions", () => {
         type: "resource",
         url: "https://example.com/resource",
         tags: ["css"],
+        submitterName: "Ada",
+        submitterGithubUsername: "ada",
       }),
       createMockContext(),
     );

--- a/netlify/functions/auth-whoami.mts
+++ b/netlify/functions/auth-whoami.mts
@@ -1,8 +1,8 @@
 import type { Config, Context } from "@netlify/functions";
-import type { User } from "@supabase/supabase-js";
-
 import {
   assertRequiredEnv,
+  getVerifiedDisplayName,
+  getVerifiedGithubUsername,
   handleMissingEnvironmentError,
   methodNotAllowed,
   ok,
@@ -10,18 +10,6 @@ import {
   unauthorized,
   verifyAuthenticatedUser,
 } from "./lib";
-
-function getDisplayName(user: User): string | null {
-  const metadata = user.user_metadata;
-  const fullName = metadata?.full_name;
-  const name = metadata?.name;
-
-  return typeof fullName === "string" && fullName.trim().length > 0
-    ? fullName
-    : typeof name === "string" && name.trim().length > 0
-      ? name
-      : (user.email ?? null);
-}
 
 export default async (req: Request, _context: Context) => {
   if (req.method !== "GET") {
@@ -46,7 +34,8 @@ export default async (req: Request, _context: Context) => {
       user: {
         id: user.id,
         email: user.email ?? null,
-        displayName: getDisplayName(user),
+        displayName: getVerifiedDisplayName(user),
+        githubUsername: getVerifiedGithubUsername(user),
         avatarUrl:
           typeof user.user_metadata?.avatar_url === "string" ? user.user_metadata.avatar_url : null,
       },

--- a/netlify/functions/lib/auth.ts
+++ b/netlify/functions/lib/auth.ts
@@ -55,18 +55,6 @@ function getMetadataString(metadata: unknown, key: string): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
-/** Returns a string list property from a Supabase metadata object. */
-function getMetadataStringList(metadata: unknown, key: string): string[] {
-  if (!metadata || typeof metadata !== "object") {
-    return [];
-  }
-
-  const value = (metadata as Record<string, unknown>)[key];
-  return Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === "string")
-    : [];
-}
-
 /** Resolves the name supplied by Supabase's verified user lookup. */
 export function getVerifiedDisplayName(user: User): string | null {
   return (
@@ -88,16 +76,7 @@ export function getVerifiedGithubUsername(user: User): string | null {
     return identityUsername;
   }
 
-  const provider = getMetadataString(user.app_metadata, "provider");
-  const hasGithubProvider =
-    provider === "github" || getMetadataStringList(user.app_metadata, "providers").includes("github");
-  const metadataUsername = hasGithubProvider
-    ? getMetadataString(user.user_metadata, "user_name")
-    : null;
-
-  return metadataUsername && isValidGithubUsername(metadataUsername)
-    ? metadataUsername
-    : null;
+  return null;
 }
 
 export async function verifyAuthenticatedUser(req: Request): Promise<AuthenticatedUser | null> {

--- a/netlify/functions/lib/auth.ts
+++ b/netlify/functions/lib/auth.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 
 import { getDb } from "./db";
 import { userRolesTable } from "../../../src/db/schema";
+import { isValidGithubUsername } from "../../../src/lib/github";
 
 function getEnv(key: string): string | undefined {
   if (typeof Netlify !== "undefined" && Netlify?.env) {
@@ -42,6 +43,61 @@ function createAuthClient() {
 export interface AuthenticatedUser {
   user: User;
   isAdmin: boolean;
+}
+
+/** Returns a non-empty string property from a Supabase metadata object. */
+function getMetadataString(metadata: unknown, key: string): string | null {
+  if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+
+  const value = (metadata as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/** Returns a string list property from a Supabase metadata object. */
+function getMetadataStringList(metadata: unknown, key: string): string[] {
+  if (!metadata || typeof metadata !== "object") {
+    return [];
+  }
+
+  const value = (metadata as Record<string, unknown>)[key];
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+/** Resolves the name supplied by Supabase's verified user lookup. */
+export function getVerifiedDisplayName(user: User): string | null {
+  return (
+    getMetadataString(user.user_metadata, "full_name") ??
+    getMetadataString(user.user_metadata, "name")
+  );
+}
+
+/** Resolves a GitHub username only from GitHub-specific Supabase provider data. */
+export function getVerifiedGithubUsername(user: User): string | null {
+  const githubIdentity = user.identities?.find(
+    (identity) => identity.provider === "github",
+  );
+  const identityUsername = getMetadataString(
+    githubIdentity?.identity_data,
+    "user_name",
+  );
+  if (identityUsername && isValidGithubUsername(identityUsername)) {
+    return identityUsername;
+  }
+
+  const provider = getMetadataString(user.app_metadata, "provider");
+  const hasGithubProvider =
+    provider === "github" || getMetadataStringList(user.app_metadata, "providers").includes("github");
+  const metadataUsername = hasGithubProvider
+    ? getMetadataString(user.user_metadata, "user_name")
+    : null;
+
+  return metadataUsername && isValidGithubUsername(metadataUsername)
+    ? metadataUsername
+    : null;
 }
 
 export async function verifyAuthenticatedUser(req: Request): Promise<AuthenticatedUser | null> {

--- a/netlify/functions/lib/index.ts
+++ b/netlify/functions/lib/index.ts
@@ -7,7 +7,12 @@ export * from "./responses";
 export { normalizeUrl, parseAndNormalizeUrl } from "./url";
 export { initSentry, captureError, flushSentry } from "./sentry";
 export { parseAggregatedTags } from "./tags";
-export { verifyAuthenticatedUser, type AuthenticatedUser } from "./auth";
+export {
+  getVerifiedDisplayName,
+  getVerifiedGithubUsername,
+  verifyAuthenticatedUser,
+  type AuthenticatedUser,
+} from "./auth";
 export { assertRequiredEnv, handleMissingEnvironmentError } from "./env";
 export {
   bookmarksTable,

--- a/netlify/functions/lib/submissions.ts
+++ b/netlify/functions/lib/submissions.ts
@@ -2,7 +2,12 @@ import type { BaseIssue } from "valibot";
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 
-import { type AuthenticatedUser, verifyAuthenticatedUser } from "./auth";
+import {
+  getVerifiedDisplayName,
+  getVerifiedGithubUsername,
+  type AuthenticatedUser,
+  verifyAuthenticatedUser,
+} from "./auth";
 import { getDb } from "./db";
 import { assertRequiredEnv, handleMissingEnvironmentError } from "./env";
 import {
@@ -266,6 +271,42 @@ function normalizeSubmitterName(
   return submitterName && submitterName.length > 0 ? submitterName : undefined;
 }
 
+/** Resolves attribution from a verified identity before accepting public form fields. */
+function resolveSubmissionAttribution(
+  submission: PublicSubmissionRequest,
+  authenticated: AuthenticatedUser | null,
+): Pick<SubmissionContext, "normalizedSubmitterGithubUrl" | "normalizedSubmitterName"> {
+  const githubUsername = authenticated
+    ? getVerifiedGithubUsername(authenticated.user)
+    : null;
+
+  return {
+    normalizedSubmitterName:
+      (authenticated ? getVerifiedDisplayName(authenticated.user) : null) ??
+      normalizeSubmitterName(submission),
+    normalizedSubmitterGithubUrl: githubUsername
+      ? `https://github.com/${githubUsername}`
+      : normalizeSubmitterGithubUrl(submission),
+  };
+}
+
+/** Returns structured errors when the resolved public attribution is incomplete. */
+function getAttributionValidationDetails(
+  attribution: Pick<SubmissionContext, "normalizedSubmitterGithubUrl" | "normalizedSubmitterName">,
+): Record<string, string[]> | null {
+  const details: Record<string, string[]> = {};
+
+  if (!attribution.normalizedSubmitterName) {
+    details.submitterName = ["Your name is required"];
+  }
+
+  if (!attribution.normalizedSubmitterGithubUrl) {
+    details.submitterGithubUsername = ["GitHub username is required"];
+  }
+
+  return Object.keys(details).length > 0 ? details : null;
+}
+
 function isPublicListingSubmission(
   submission: PublicSubmissionRequest,
 ): submission is PublicSubmissionRequest & {
@@ -473,12 +514,15 @@ export async function handlePublicSubmission(
     });
   }
 
+  const attribution = resolveSubmissionAttribution(validation.output, authenticated);
+  const attributionDetails = getAttributionValidationDetails(attribution);
+  if (attributionDetails) {
+    return validationError("Validation failed", attributionDetails);
+  }
+
   const submissionContext: SubmissionContext = {
     authenticated,
-    normalizedSubmitterGithubUrl: normalizeSubmitterGithubUrl(
-      validation.output,
-    ),
-    normalizedSubmitterName: normalizeSubmitterName(validation.output),
+    ...attribution,
     normalizedUrl: publicUrl,
     submission: validation.output,
     tags,

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -6,6 +6,7 @@ const authUserSchema = v.object({
   id: v.string(),
   email: v.nullable(v.string()),
   displayName: v.nullable(v.string()),
+  githubUsername: v.nullable(v.string()),
   avatarUrl: v.nullable(v.string()),
 });
 

--- a/src/components/__tests__/SubmitPage.test.tsx
+++ b/src/components/__tests__/SubmitPage.test.tsx
@@ -1,16 +1,112 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SubmitPage } from "../../pages/SubmitPage";
 import { server } from "../../test/mocks/server";
+import { useAuth } from "../../hooks/useAuth";
+
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+const authDefaults = {
+  identity: null,
+  session: null,
+  accessToken: null,
+  isAdmin: false,
+  isAuthenticated: false,
+  isLoading: false,
+  error: null,
+  signInWithGoogle: vi.fn(),
+  signInWithGitHub: vi.fn(),
+  signOut: vi.fn(),
+  refreshIdentity: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.mocked(useAuth).mockReturnValue(authDefaults);
+});
 
 describe("SubmitPage", () => {
-  it("submits the existing tool form through the public submission endpoint", async () => {
+  it("requires a binary type and anonymous attribution", async () => {
+    const user = userEvent.setup();
+    render(<SubmitPage />);
+
+    expect(screen.getByRole("heading", { name: "Submit a Resource" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Tool" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Resource" })).not.toBeChecked();
+    expect(screen.queryByRole("radio", { name: /article/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Your name" })).toBeRequired();
+    expect(screen.getByRole("textbox", { name: "GitHub username" })).toBeRequired();
+
+    await user.click(screen.getByRole("button", { name: "Submit Resource" }));
+
+    expect(screen.getByText("Please select a content type")).toBeInTheDocument();
+    expect(screen.getByText("Your name is required")).toBeInTheDocument();
+    expect(screen.getByText("GitHub username is required")).toBeInTheDocument();
+  });
+
+  it("submits a resource with anonymous attribution", async () => {
     let requestBody: unknown;
     server.use(
       http.post("/api/submissions", async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json(
+          {
+            success: true,
+            data: {
+              submittedItemId: "11111111-1111-4111-8111-111111111111",
+              type: "resource",
+              status: "pending",
+              message: "Resource submitted.",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+    const user = userEvent.setup();
+    render(<SubmitPage />);
+
+    await user.click(screen.getByRole("radio", { name: "Resource" }));
+    await user.type(screen.getByRole("textbox", { name: "URL" }), "https://example.com/guide");
+    await user.type(screen.getByRole("textbox", { name: /^tags/i }), "testing{Enter}");
+    await user.type(screen.getByRole("textbox", { name: "Your name" }), "Ada Lovelace");
+    await user.type(screen.getByRole("textbox", { name: "GitHub username" }), "ada-lovelace");
+    await user.click(screen.getByRole("button", { name: "Submit Resource" }));
+
+    expect(await screen.findByText(/submission received/i)).toBeInTheDocument();
+    expect(requestBody).toEqual({
+      type: "resource",
+      url: "https://example.com/guide",
+      tags: ["testing"],
+      submitterName: "Ada Lovelace",
+      submitterGithubUsername: "ada-lovelace",
+    });
+  });
+
+  it("hides a verified name and sends the access token", async () => {
+    let authorization: string | null = null;
+    let requestBody: unknown;
+    vi.mocked(useAuth).mockReturnValue({
+      ...authDefaults,
+      identity: {
+        user: {
+          id: "user-1",
+          email: "ada@example.com",
+          displayName: "Ada Lovelace",
+          avatarUrl: null,
+        },
+        isAdmin: false,
+      },
+      accessToken: "verified-token",
+      isAuthenticated: true,
+    });
+    server.use(
+      http.post("/api/submissions", async ({ request }) => {
+        authorization = request.headers.get("Authorization");
         requestBody = await request.json();
         return HttpResponse.json(
           {
@@ -29,24 +125,45 @@ describe("SubmitPage", () => {
     const user = userEvent.setup();
     render(<SubmitPage />);
 
-    await user.type(
-      screen.getByRole("textbox", { name: /tool url/i }),
-      "https://example.com/tool",
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: /^tags/i }),
-      "testing{Enter}",
-    );
-    await user.click(screen.getByRole("button", { name: "Submit Tool" }));
+    expect(screen.queryByRole("textbox", { name: "Your name" })).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "GitHub username" })).toBeInTheDocument();
 
-    expect(
-      await screen.findByText(/tool submitted successfully/i),
-    ).toBeInTheDocument();
+    await user.click(screen.getByRole("radio", { name: "Tool" }));
+    await user.type(screen.getByRole("textbox", { name: "URL" }), "https://example.com/tool");
+    await user.type(screen.getByRole("textbox", { name: /^tags/i }), "testing{Enter}");
+    await user.type(screen.getByRole("textbox", { name: "GitHub username" }), "ada-lovelace");
+    await user.click(screen.getByRole("button", { name: "Submit Resource" }));
+
+    await screen.findByText(/submission received/i);
+    expect(authorization).toBe("Bearer verified-token");
     expect(requestBody).toEqual({
       type: "tool",
       url: "https://example.com/tool",
       tags: ["testing"],
+      submitterGithubUsername: "ada-lovelace",
     });
+  });
+
+  it("asks a signed-in user for a missing verified name", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      ...authDefaults,
+      identity: {
+        user: {
+          id: "user-1",
+          email: null,
+          displayName: null,
+          avatarUrl: null,
+        },
+        isAdmin: false,
+      },
+      accessToken: "verified-token",
+      isAuthenticated: true,
+    });
+
+    render(<SubmitPage />);
+
+    expect(screen.getByRole("textbox", { name: "Your name" })).toBeRequired();
+    expect(screen.getByText(/account does not include a name/i)).toBeInTheDocument();
   });
 
   it("renders structured server validation details", async () => {
@@ -65,19 +182,14 @@ describe("SubmitPage", () => {
     const user = userEvent.setup();
     render(<SubmitPage />);
 
-    await user.type(
-      screen.getByRole("textbox", { name: /tool url/i }),
-      "https://example.com/tool",
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: /^tags/i }),
-      "testing{Enter}",
-    );
-    await user.click(screen.getByRole("button", { name: "Submit Tool" }));
+    await user.click(screen.getByRole("radio", { name: "Tool" }));
+    await user.type(screen.getByRole("textbox", { name: "URL" }), "https://example.com/tool");
+    await user.type(screen.getByRole("textbox", { name: /^tags/i }), "testing{Enter}");
+    await user.type(screen.getByRole("textbox", { name: "Your name" }), "Ada Lovelace");
+    await user.type(screen.getByRole("textbox", { name: "GitHub username" }), "ada-lovelace");
+    await user.click(screen.getByRole("button", { name: "Submit Resource" }));
 
     expect(await screen.findByText(/submission failed/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/url: this domain is blocked/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/url: this domain is blocked/i)).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/SubmitPage.test.tsx
+++ b/src/components/__tests__/SubmitPage.test.tsx
@@ -30,6 +30,52 @@ beforeEach(() => {
 });
 
 describe("SubmitPage", () => {
+  it("holds attribution requirements until auth resolves to a signed-in identity", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      ...authDefaults,
+      isLoading: true,
+    });
+    const { rerender } = render(<SubmitPage />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Checking your session…");
+    expect(screen.getByRole("form", { name: "Submit a Resource" })).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+    expect(screen.getByRole("radio", { name: "Tool" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Submit Resource" })).toBeDisabled();
+    expect(screen.queryByRole("textbox", { name: "Your name" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "GitHub username" })).not.toBeInTheDocument();
+
+    vi.mocked(useAuth).mockReturnValue({
+      ...authDefaults,
+      identity: {
+        user: {
+          id: "user-1",
+          email: "ada@example.com",
+          displayName: "Ada Lovelace",
+          githubUsername: "ada-lovelace",
+          avatarUrl: null,
+        },
+        isAdmin: false,
+      },
+      accessToken: "verified-token",
+      isAuthenticated: true,
+      isLoading: false,
+    });
+    rerender(<SubmitPage />);
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByRole("form", { name: "Submit a Resource" })).toHaveAttribute(
+      "aria-busy",
+      "false",
+    );
+    expect(screen.getByRole("radio", { name: "Tool" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Submit Resource" })).toBeEnabled();
+    expect(screen.queryByRole("textbox", { name: "Your name" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "GitHub username" })).not.toBeInTheDocument();
+  });
+
   it("requires a binary type and anonymous attribution", async () => {
     const user = userEvent.setup();
     render(<SubmitPage />);

--- a/src/components/__tests__/SubmitPage.test.tsx
+++ b/src/components/__tests__/SubmitPage.test.tsx
@@ -97,6 +97,7 @@ describe("SubmitPage", () => {
           id: "user-1",
           email: "ada@example.com",
           displayName: "Ada Lovelace",
+          githubUsername: "ada-lovelace",
           avatarUrl: null,
         },
         isAdmin: false,
@@ -126,22 +127,20 @@ describe("SubmitPage", () => {
     render(<SubmitPage />);
 
     expect(screen.queryByRole("textbox", { name: "Your name" })).not.toBeInTheDocument();
-    expect(screen.getByRole("textbox", { name: "GitHub username" })).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "GitHub username" })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("radio", { name: "Tool" }));
     await user.type(screen.getByRole("textbox", { name: "URL" }), "https://example.com/tool");
     await user.type(screen.getByRole("textbox", { name: /^tags/i }), "testing{Enter}");
-    await user.type(screen.getByRole("textbox", { name: "GitHub username" }), "ada-lovelace");
     await user.click(screen.getByRole("button", { name: "Submit Resource" }));
 
     await screen.findByText(/submission received/i);
     expect(authorization).toBe("Bearer verified-token");
     expect(requestBody).toEqual({
-      type: "tool",
-      url: "https://example.com/tool",
-      tags: ["testing"],
-      submitterGithubUsername: "ada-lovelace",
-    });
+        type: "tool",
+        url: "https://example.com/tool",
+        tags: ["testing"],
+      });
   });
 
   it("asks a signed-in user for a missing verified name", () => {
@@ -152,6 +151,7 @@ describe("SubmitPage", () => {
           id: "user-1",
           email: null,
           displayName: null,
+          githubUsername: null,
           avatarUrl: null,
         },
         isAdmin: false,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -53,7 +53,7 @@ export function Header() {
               Library
             </LinkButton>
           )}
-          <LinkButton to="/submit">Submit Tool</LinkButton>
+          <LinkButton to="/submit">Submit Resource</LinkButton>
         </nav>
         <div className="Header-auth">
           {isAuthenticated ? (

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -55,6 +55,7 @@ describe("Header", () => {
           id: "user-1",
           email: "test@example.com",
           displayName: "Test User",
+          githubUsername: null,
           avatarUrl: null,
         },
         isAdmin: true,

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -41,6 +41,10 @@ describe("Header", () => {
     renderHeader();
 
     expect(screen.getByText("Sign in")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Submit Resource" })).toHaveAttribute(
+      "href",
+      "/submit",
+    );
     expect(screen.queryByRole("link", { name: "Library" })).not.toBeInTheDocument();
   });
 

--- a/src/hooks/__tests__/usePublicSubmission.test.tsx
+++ b/src/hooks/__tests__/usePublicSubmission.test.tsx
@@ -40,6 +40,40 @@ beforeEach(() => {
 });
 
 describe("usePublicSubmission", () => {
+  it("forwards the access token to the submission client", async () => {
+    let authorization: string | null = null;
+    server.use(
+      http.post("/api/submissions", ({ request }) => {
+        authorization = request.headers.get("Authorization");
+        return HttpResponse.json(
+          {
+            success: true,
+            data: {
+              submittedItemId,
+              type: "tool",
+              status: "pending",
+              message: "Tool submitted.",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+    const { result } = renderHook(() =>
+      usePublicSubmission({ accessToken: "verified-token" }),
+    );
+
+    await act(async () => {
+      await result.current.submit({
+        type: "tool",
+        url: "https://example.com/tool",
+        tags: ["testing"],
+      });
+    });
+
+    expect(authorization).toBe("Bearer verified-token");
+  });
+
   it("submits successfully and stores the response", async () => {
     const { result } = renderHook(() => usePublicSubmission());
 

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -151,7 +151,7 @@ describe("Validation Schemas", () => {
       ).toBe(true);
     });
 
-    it("should validate optional authenticated user context", () => {
+    it("should reject client-supplied authenticated user context", () => {
       const result = validatePublicSubmissionRequest({
         type: "resource",
         url: "https://example.com/resource",
@@ -161,7 +161,7 @@ describe("Validation Schemas", () => {
         },
       });
 
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
     it("should reject unsupported public submission types", () => {
@@ -184,18 +184,6 @@ describe("Validation Schemas", () => {
       expect(result.success).toBe(false);
     });
 
-    it("should reject invalid authenticated user ids", () => {
-      const result = validatePublicSubmissionRequest({
-        type: "resource",
-        url: "https://example.com/resource",
-        tags: ["reference"],
-        authenticatedUser: {
-          userId: "not-a-user-id",
-        },
-      });
-
-      expect(result.success).toBe(false);
-    });
   });
 
   describe("validatePublicSubmissionResponse", () => {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -69,19 +69,13 @@ const optionalGithubUsernameSchema = v.optional(
 export const publicSubmissionTypeSchema = v.picklist(["tool", "resource"]);
 export const publicSubmissionStatusSchema = v.picklist(["pending", "approved", "rejected"]);
 
-export const publicSubmissionAuthenticatedUserSchema = v.object({
-  userId: v.pipe(v.string(), v.uuid("Authenticated user id must be a valid UUID")),
-});
-
-// Server-side code should populate this from verified auth context, not trust arbitrary client JSON.
-export const publicSubmissionRequestSchema = v.object({
+export const publicSubmissionRequestSchema = v.strictObject({
   type: publicSubmissionTypeSchema,
   url: resourceUrlSchema,
   tags: resourceTagsSchema,
   submitterName: optionalSubmitterNameSchema,
   submitterGithubUsername: optionalGithubUsernameSchema,
   submitterGithubUrl: optionalGithubProfileUrlSchema,
-  authenticatedUser: v.optional(publicSubmissionAuthenticatedUserSchema),
 });
 
 export const publicSubmissionResponseDataSchema = v.object({

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -11,28 +11,28 @@ export function AboutPage() {
       <section>
         <h2 className="heading-2xl">What MakerBench Is</h2>
         <p>
-          MakerBench is a curated directory of tools for makers, developers, and teams building
-          products on the web. The goal is simple: make it easier to discover useful tools without
-          turning the site into a noisy list of everything on the internet.
+          MakerBench is a curated directory of tools and resources for makers, developers, and
+          teams building products on the web. The goal is simple: make useful links easier to
+          discover without turning the site into a noisy list of everything on the internet.
         </p>
       </section>
 
       <section>
         <h2 className="heading-2xl">How It Works</h2>
         <p>
-          Tools can be submitted by the community and are reviewed before they appear in the
-          directory. Each approved listing includes the tool metadata we can reliably collect,
-          relevant tags, and a screenshot or image so visitors can quickly evaluate whether it is
+          Tools and resources can be submitted by the community and are reviewed before they appear
+          in the catalog. Each approved listing includes the metadata we can reliably collect,
+          relevant tags, and an image when available so visitors can quickly evaluate whether it is
           worth exploring.
         </p>
       </section>
 
       <section>
-        <h2 className="heading-2xl">Contributing Tools</h2>
+        <h2 className="heading-2xl">Contributing Resources</h2>
         <p>
-          If you know a tool that belongs here, use the <a href="/submit">submission form</a>. A
-          good submission starts with the tool URL and a small set of accurate tags. You can also
-          include your name and GitHub username if you want credit shown on the card.
+          If you know a tool, article, guide, reference, or other resource that belongs here, use
+          the <a href="/submit">submission form</a>. Choose whether it is a tool or resource, then
+          add its URL and a small set of accurate tags.
         </p>
         <p>
           Submissions are reviewed before publication so the directory stays useful, consistent, and

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -378,7 +378,9 @@ export function HomePage() {
         isLoading={isLoading && tools.length === 0}
         emptyTitle={isFiltering ? "No matching tools" : "No tools yet"}
         emptyDescription={
-          isFiltering ? "Try adjusting your search or filters." : "Be the first to submit a tool!"
+          isFiltering
+            ? "Try adjusting your search or filters."
+            : "Be the first to submit a resource!"
         }
       />
 

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -14,30 +14,33 @@ export function PrivacyPage() {
       <section>
         <h2 className="heading-2xl">Overview</h2>
         <p>
-          MakerBench is a curated tool directory. This policy explains what information we collect,
-          how we use it, and which third-party services help us run the site.
+          MakerBench is a curated directory of tools and resources. This policy explains what
+          information we collect, how we use it, and which third-party services help us run the
+          site.
         </p>
       </section>
 
       <section>
         <h2 className="heading-2xl">Information You Provide</h2>
-        <p>When you submit a tool, we collect the information entered into the submission form:</p>
+        <p>When you submit a resource, we collect the information entered into the submission form:</p>
         <ul>
           <li>
-            <span className="PrivacyPage-emphasis">Tool URL:</span> required so we can review the
-            submitted site.
+            <span className="PrivacyPage-emphasis">Submission type and URL:</span> required so we
+            can route and review the submitted tool or resource.
           </li>
           <li>
             <span className="PrivacyPage-emphasis">Tags:</span> required so we can classify the
             submission.
           </li>
           <li>
-            <span className="PrivacyPage-emphasis">Your name:</span> optional and only used for
-            attribution if the tool is approved.
+            <span className="PrivacyPage-emphasis">Your name:</span> required for signed-out
+            submissions and used for attribution if the submission is approved. Signed-in accounts
+            may provide this through their verified identity.
           </li>
           <li>
-            <span className="PrivacyPage-emphasis">Your GitHub username:</span> optional and only
-            used to link your attribution on an approved listing.
+            <span className="PrivacyPage-emphasis">Your GitHub username:</span> required when it
+            cannot be resolved from a signed-in identity and used to link attribution on an approved
+            listing.
           </li>
         </ul>
         <p>
@@ -49,7 +52,7 @@ export function PrivacyPage() {
       <section>
         <h2 className="heading-2xl">Information We Derive During Review</h2>
         <p>
-          When a tool is submitted, MakerBench may fetch public metadata from the submitted URL,
+          When a tool or resource is submitted, MakerBench may fetch public metadata from its URL,
           such as the page title, description, and preview image. If needed, we may also generate a
           screenshot of the submitted site for the directory card.
         </p>
@@ -75,8 +78,8 @@ export function PrivacyPage() {
       <section>
         <h2 className="heading-2xl">How We Use Information</h2>
         <ul>
-          <li>Review and publish tool submissions</li>
-          <li>Display approved listings and optional submitter attribution</li>
+          <li>Review and publish tool and resource submissions</li>
+          <li>Display approved listings and submitter attribution</li>
           <li>Operate, secure, and improve the site</li>
           <li>Diagnose outages, bugs, and abuse</li>
           <li>Understand overall usage trends through analytics</li>
@@ -141,8 +144,7 @@ export function PrivacyPage() {
         <h2 className="heading-2xl">Your Choices</h2>
         <p>
           If you want a submitted name or GitHub attribution corrected or removed, open an issue in
-          the project repository. If you do not want attribution displayed, do not include the
-          optional attribution fields when submitting a tool.
+          the project repository.
         </p>
       </section>
 

--- a/src/pages/SubmitPage.css
+++ b/src/pages/SubmitPage.css
@@ -32,6 +32,11 @@
   gap: var(--size-32);
 }
 
+.SubmitPage-authStatus {
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
 .SubmitPage-fieldset {
   border: none;
   display: flex;

--- a/src/pages/SubmitPage.css
+++ b/src/pages/SubmitPage.css
@@ -45,6 +45,67 @@
   opacity: 0.6;
 }
 
+.SubmitPage-typeFieldset {
+  gap: var(--size-16);
+}
+
+.SubmitPage-typeOptions {
+  display: grid;
+  gap: var(--size-12);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.SubmitPage-typeOption {
+  align-items: flex-start;
+  background: var(--color-surface-raised);
+  border: var(--size-1) solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  display: flex;
+  gap: var(--size-12);
+  min-block-size: var(--size-80);
+  padding: var(--size-16);
+  transition:
+    border-color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.SubmitPage-typeOption:has(.SubmitPage-typeInput:checked) {
+  background: var(--color-surface-sunken);
+  border-color: var(--color-border-strong);
+}
+
+.SubmitPage-typeOption:has(.SubmitPage-typeInput:focus-visible) {
+  outline: var(--focus-ring-width) solid var(--color-focus-ring);
+  outline-offset: var(--focus-ring-offset-sm);
+}
+
+.SubmitPage-typeInput {
+  accent-color: var(--color-primary);
+  block-size: var(--size-20);
+  flex: 0 0 var(--size-20);
+  inline-size: var(--size-20);
+  margin: 0;
+}
+
+.SubmitPage-typeLabel {
+  color: var(--color-text);
+  display: block;
+  font-weight: var(--font-weight-semibold);
+}
+
+.SubmitPage-typeHint {
+  color: var(--color-text-muted);
+  display: block;
+  margin-block-start: var(--size-4);
+}
+
+.SubmitPage-fieldError {
+  color: var(--color-error);
+  font-size: var(--text-sm);
+  margin: 0;
+}
+
 .SubmitPage-legend {
   color: var(--color-text);
   margin-block-end: var(--size-16);
@@ -59,4 +120,10 @@
 .SubmitPage-errorDetails {
   margin-block-start: var(--size-8);
   padding-inline-start: var(--size-20);
+}
+
+@media (width < 30rem) {
+  .SubmitPage-typeOptions {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }

--- a/src/pages/SubmitPage.tsx
+++ b/src/pages/SubmitPage.tsx
@@ -76,7 +76,7 @@ function getFormErrors(issues: readonly v.BaseIssue<unknown>[]): FormErrors {
 
 /** Public tool and resource submission form. */
 export function SubmitPage() {
-  const { identity, accessToken, isAuthenticated } = useAuth();
+  const { identity, accessToken, isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const { submit, isSubmitting, error, response, reset } = usePublicSubmission({
     accessToken: accessToken ?? undefined,
   });
@@ -84,6 +84,7 @@ export function SubmitPage() {
   const hasVerifiedGithubUsername = Boolean(identity?.user.githubUsername?.trim());
   const requireName = !hasVerifiedName;
   const requireGithubUsername = !hasVerifiedGithubUsername;
+  const isFormDisabled = isAuthLoading || isSubmitting;
 
   const [submissionType, setSubmissionType] = useState<PublicSubmissionType | "">("");
   const [url, setUrl] = useState("");
@@ -95,6 +96,10 @@ export function SubmitPage() {
   /** Handles form submission after client-side contract validation. */
   async function handleSubmit(event: FormEvent) {
     event.preventDefault();
+
+    if (isAuthLoading) {
+      return;
+    }
 
     const result = v.safeParse(
       getSubmissionFormSchema(requireName, requireGithubUsername),
@@ -139,7 +144,9 @@ export function SubmitPage() {
   return (
     <div className="SubmitPage">
       <header className="SubmitPage-header">
-        <h1 className="SubmitPage-title heading-2xl">Submit a Resource</h1>
+        <h1 id="submit-page-title" className="SubmitPage-title heading-2xl">
+          Submit a Resource
+        </h1>
         <p className="SubmitPage-description body-base">
           Share a useful tool or resource with the community for review.
         </p>
@@ -166,10 +173,22 @@ export function SubmitPage() {
         </Alert>
       ) : null}
 
-      <form className="SubmitPage-form" onSubmit={handleSubmit} noValidate>
+      <form
+        className="SubmitPage-form"
+        onSubmit={handleSubmit}
+        noValidate
+        aria-labelledby="submit-page-title"
+        aria-busy={isAuthLoading}
+      >
+        {isAuthLoading ? (
+          <p className="SubmitPage-authStatus body-base" role="status">
+            Checking your session…
+          </p>
+        ) : null}
+
         <fieldset
           className="SubmitPage-fieldset SubmitPage-typeFieldset"
-          disabled={isSubmitting}
+          disabled={isFormDisabled}
           aria-describedby={formErrors.type ? "submission-type-error" : undefined}
         >
           <legend className="SubmitPage-legend ui-label">What are you submitting?</legend>
@@ -211,7 +230,7 @@ export function SubmitPage() {
           ) : null}
         </fieldset>
 
-        <fieldset className="SubmitPage-fieldset" disabled={isSubmitting}>
+        <fieldset className="SubmitPage-fieldset" disabled={isFormDisabled}>
           <legend className="visually-hidden">Submission details</legend>
 
           <TextInput
@@ -243,8 +262,8 @@ export function SubmitPage() {
           />
         </fieldset>
 
-        {(requireName || requireGithubUsername) ? (
-          <fieldset className="SubmitPage-fieldset" disabled={isSubmitting}>
+        {!isAuthLoading && (requireName || requireGithubUsername) ? (
+          <fieldset className="SubmitPage-fieldset" disabled={isFormDisabled}>
             <legend className="SubmitPage-legend ui-label">Your details</legend>
 
             {requireName ? (
@@ -282,7 +301,12 @@ export function SubmitPage() {
         ) : null}
 
         <div className="SubmitPage-actions">
-          <Button type="submit" variant="primary" isLoading={isSubmitting}>
+          <Button
+            type="submit"
+            variant="primary"
+            isLoading={isSubmitting}
+            disabled={isAuthLoading}
+          >
             {isSubmitting ? "Submitting…" : "Submit Resource"}
           </Button>
         </div>

--- a/src/pages/SubmitPage.tsx
+++ b/src/pages/SubmitPage.tsx
@@ -1,101 +1,136 @@
 import { useState, type FormEvent } from "react";
 import * as v from "valibot";
 
-import { Alert } from "../components/ui";
-import { TextInput } from "../components/ui";
-import { Button } from "../components/ui";
 import { TagInput } from "../components/forms";
+import { Alert, Button, TextInput } from "../components/ui";
+import { useAuth } from "../hooks/useAuth";
 import { usePublicSubmission } from "../hooks/usePublicSubmission";
-import { bookmarkRequestSchema, type BookmarkRequest } from "../lib/validation";
+import {
+  publicSubmissionRequestSchema,
+  type PublicSubmissionType,
+} from "../lib/validation";
 
 import "./SubmitPage.css";
 
 interface FormErrors {
+  type?: string;
   url?: string;
   tags?: string;
   submitterName?: string;
   submitterGithubUsername?: string;
 }
 
-/**
- * Submit page - form for submitting new tools.
- */
-export function SubmitPage() {
-  const { submit, isSubmitting, error, response, reset } = usePublicSubmission();
+const submissionTypeOptions: Array<{
+  value: PublicSubmissionType;
+  label: string;
+  hint: string;
+}> = [
+  {
+    value: "tool",
+    label: "Tool",
+    hint: "A developer or maker tool.",
+  },
+  {
+    value: "resource",
+    label: "Resource",
+    hint: "An article, guide, reference, or other useful link.",
+  },
+];
 
-  // Form state
+/** Builds form validation around the attribution missing from verified identity. */
+function getSubmissionFormSchema(requireName: boolean, requireGithubUsername: boolean) {
+  return v.pipe(
+    publicSubmissionRequestSchema,
+    v.forward(
+      v.check(
+        (input) => !requireName || Boolean(input.submitterName?.trim()),
+        "Your name is required",
+      ),
+      ["submitterName"],
+    ),
+    v.forward(
+      v.check(
+        (input) =>
+          !requireGithubUsername || Boolean(input.submitterGithubUsername?.trim()),
+        "GitHub username is required",
+      ),
+      ["submitterGithubUsername"],
+    ),
+  );
+}
+
+/** Maps the first Valibot issue for each form field to display copy. */
+function getFormErrors(issues: readonly v.BaseIssue<unknown>[]): FormErrors {
+  const errors: FormErrors = {};
+
+  for (const issue of issues) {
+    const pathItem = issue.path?.[0] as { key?: unknown } | undefined;
+    const field = pathItem?.key as keyof FormErrors | undefined;
+    if (field && !errors[field]) {
+      errors[field] = issue.message;
+    }
+  }
+
+  return errors;
+}
+
+/** Public tool and resource submission form. */
+export function SubmitPage() {
+  const { identity, accessToken, isAuthenticated } = useAuth();
+  const { submit, isSubmitting, error, response, reset } = usePublicSubmission({
+    accessToken: accessToken ?? undefined,
+  });
+  const hasVerifiedName = Boolean(identity?.user.displayName?.trim());
+  const requireName = !hasVerifiedName;
+  // whoami does not currently expose a verified GitHub username.
+  const requireGithubUsername = true;
+
+  const [submissionType, setSubmissionType] = useState<PublicSubmissionType | "">("");
   const [url, setUrl] = useState("");
   const [tags, setTags] = useState<string[]>([]);
   const [submitterName, setSubmitterName] = useState("");
   const [submitterGithubUsername, setSubmitterGithubUsername] = useState("");
   const [formErrors, setFormErrors] = useState<FormErrors>({});
 
-  /**
-   * Validates form and returns errors object.
-   */
-  function validateForm(): FormErrors {
-    const data = {
-      url: url.trim(),
-      tags,
-      submitterName: submitterName.trim() || undefined,
-      submitterGithubUsername: submitterGithubUsername.trim() || undefined,
-    };
-
-    const result = v.safeParse(bookmarkRequestSchema, data);
-
-    if (result.success) {
-      return {};
-    }
-
-    const errors: FormErrors = {};
-    for (const issue of result.issues) {
-      const pathItem = issue.path?.[0] as { key?: unknown } | undefined;
-      const field = pathItem?.key as keyof FormErrors | undefined;
-      if (!field) {
-        continue;
-      }
-      if (!errors[field]) {
-        errors[field] = issue.message;
-      }
-    }
-    return errors;
-  }
-
-  /**
-   * Handles form submission.
-   */
+  /** Handles form submission after client-side contract validation. */
   async function handleSubmit(event: FormEvent) {
     event.preventDefault();
 
-    const errors = validateForm();
-    setFormErrors(errors);
+    const result = v.safeParse(
+      getSubmissionFormSchema(requireName, requireGithubUsername),
+      {
+        type: submissionType,
+        url: url.trim(),
+        tags,
+        submitterName: requireName ? submitterName.trim() : undefined,
+        submitterGithubUsername: requireGithubUsername
+          ? submitterGithubUsername.trim()
+          : undefined,
+      },
+    );
 
-    if (Object.keys(errors).length > 0) {
+    if (!result.success) {
+      const errors = getFormErrors(result.issues);
+      if (!submissionType) {
+        errors.type = "Please select a content type";
+      }
+      setFormErrors(errors);
       return;
     }
 
-    const data: BookmarkRequest = {
-      url: url.trim(),
-      tags,
-      submitterName: submitterName.trim() || undefined,
-      submitterGithubUsername: submitterGithubUsername.trim() || undefined,
-    };
+    setFormErrors({});
+    const submission = await submit(result.output);
 
-    const result = await submit({ ...data, type: "tool" });
-
-    if (result) {
-      // Reset form on success
+    if (submission) {
+      setSubmissionType("");
       setUrl("");
       setTags([]);
       setSubmitterName("");
       setSubmitterGithubUsername("");
-      setFormErrors({});
     }
   }
 
-  /**
-   * Resets form and clears submission state.
-   */
+  /** Clears submission feedback and client validation. */
   function handleReset() {
     reset();
     setFormErrors({});
@@ -104,22 +139,22 @@ export function SubmitPage() {
   return (
     <div className="SubmitPage">
       <header className="SubmitPage-header">
-        <h1 className="SubmitPage-title heading-2xl">Submit a Tool</h1>
+        <h1 className="SubmitPage-title heading-2xl">Submit a Resource</h1>
         <p className="SubmitPage-description body-base">
-          Share a useful tool or resource with the community.
+          Share a useful tool or resource with the community for review.
         </p>
       </header>
 
-      {response && (
+      {response ? (
         <Alert variant="success" dismissible onDismiss={handleReset}>
-          <strong>Tool submitted successfully!</strong> It will appear on the site after review.
+          <strong>Submission received.</strong> It will appear on the site after review.
         </Alert>
-      )}
+      ) : null}
 
-      {error && (
+      {error ? (
         <Alert variant="error" dismissible onDismiss={handleReset}>
           <strong>Submission failed.</strong> {error.message}
-          {error.details && (
+          {error.details ? (
             <ul className="SubmitPage-errorDetails body-sm">
               {Object.entries(error.details).map(([field, messages]) => (
                 <li key={field}>
@@ -127,28 +162,76 @@ export function SubmitPage() {
                 </li>
               ))}
             </ul>
-          )}
+          ) : null}
         </Alert>
-      )}
+      ) : null}
 
       <form className="SubmitPage-form" onSubmit={handleSubmit} noValidate>
+        <fieldset
+          className="SubmitPage-fieldset SubmitPage-typeFieldset"
+          disabled={isSubmitting}
+          aria-describedby={formErrors.type ? "submission-type-error" : undefined}
+        >
+          <legend className="SubmitPage-legend ui-label">What are you submitting?</legend>
+          <div className="SubmitPage-typeOptions">
+            {submissionTypeOptions.map((option) => {
+              const labelId = `submission-type-${option.value}-label`;
+              const hintId = `submission-type-${option.value}-hint`;
+
+              return (
+                <label className="SubmitPage-typeOption" key={option.value}>
+                  <input
+                    className="SubmitPage-typeInput"
+                    type="radio"
+                    name="submission-type"
+                    value={option.value}
+                    checked={submissionType === option.value}
+                    onChange={() => setSubmissionType(option.value)}
+                    aria-labelledby={labelId}
+                    aria-describedby={hintId}
+                    aria-invalid={formErrors.type ? true : undefined}
+                    required
+                  />
+                  <span>
+                    <span id={labelId} className="SubmitPage-typeLabel">
+                      {option.label}
+                    </span>
+                    <span id={hintId} className="SubmitPage-typeHint body-sm">
+                      {option.hint}
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+          {formErrors.type ? (
+            <p id="submission-type-error" className="SubmitPage-fieldError" role="alert">
+              {formErrors.type}
+            </p>
+          ) : null}
+        </fieldset>
+
         <fieldset className="SubmitPage-fieldset" disabled={isSubmitting}>
-          <legend className="visually-hidden">Tool Details</legend>
+          <legend className="visually-hidden">Submission details</legend>
 
           <TextInput
-            id="tool-url"
-            label="Tool URL"
+            id="submission-url"
+            label="URL"
             type="url"
             value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            placeholder="https://example.com/tool"
+            onChange={(event) => setUrl(event.target.value)}
+            placeholder={
+              submissionType === "tool"
+                ? "https://example.com/tool"
+                : "https://example.com/resource"
+            }
             required
             error={formErrors.url}
-            hint="The main URL of the tool or resource"
+            hint="The main URL for the submission"
           />
 
           <TagInput
-            id="tool-tags"
+            id="submission-tags"
             label="Tags"
             tags={tags}
             onTagsChange={setTags}
@@ -160,35 +243,47 @@ export function SubmitPage() {
           />
         </fieldset>
 
-        <fieldset className="SubmitPage-fieldset" disabled={isSubmitting}>
-          <legend className="SubmitPage-legend ui-label">Your Details (Optional)</legend>
+        {(requireName || requireGithubUsername) ? (
+          <fieldset className="SubmitPage-fieldset" disabled={isSubmitting}>
+            <legend className="SubmitPage-legend ui-label">Your details</legend>
 
-          <TextInput
-            id="submitter-name"
-            label="Your Name"
-            type="text"
-            value={submitterName}
-            onChange={(e) => setSubmitterName(e.target.value)}
-            placeholder="Jane Developer"
-            error={formErrors.submitterName}
-            hint="Get credited for your submission"
-          />
+            {requireName ? (
+              <TextInput
+                id="submitter-name"
+                label="Your name"
+                type="text"
+                value={submitterName}
+                onChange={(event) => setSubmitterName(event.target.value)}
+                placeholder="Jane Developer"
+                required
+                error={formErrors.submitterName}
+                hint={
+                  isAuthenticated
+                    ? "Required because your account does not include a name"
+                    : "Used to credit your submission"
+                }
+              />
+            ) : null}
 
-          <TextInput
-            id="submitter-github-username"
-            label="GitHub Username"
-            type="text"
-            value={submitterGithubUsername}
-            onChange={(e) => setSubmitterGithubUsername(e.target.value)}
-            placeholder="username"
-            error={formErrors.submitterGithubUsername}
-            hint="Your GitHub username for profile link"
-          />
-        </fieldset>
+            {requireGithubUsername ? (
+              <TextInput
+                id="submitter-github-username"
+                label="GitHub username"
+                type="text"
+                value={submitterGithubUsername}
+                onChange={(event) => setSubmitterGithubUsername(event.target.value)}
+                placeholder="username"
+                required
+                error={formErrors.submitterGithubUsername}
+                hint="Used to link your attribution to your GitHub profile"
+              />
+            ) : null}
+          </fieldset>
+        ) : null}
 
         <div className="SubmitPage-actions">
           <Button type="submit" variant="primary" isLoading={isSubmitting}>
-            {isSubmitting ? "Submitting…" : "Submit Tool"}
+            {isSubmitting ? "Submitting…" : "Submit Resource"}
           </Button>
         </div>
       </form>

--- a/src/pages/SubmitPage.tsx
+++ b/src/pages/SubmitPage.tsx
@@ -81,9 +81,9 @@ export function SubmitPage() {
     accessToken: accessToken ?? undefined,
   });
   const hasVerifiedName = Boolean(identity?.user.displayName?.trim());
+  const hasVerifiedGithubUsername = Boolean(identity?.user.githubUsername?.trim());
   const requireName = !hasVerifiedName;
-  // whoami does not currently expose a verified GitHub username.
-  const requireGithubUsername = true;
+  const requireGithubUsername = !hasVerifiedGithubUsername;
 
   const [submissionType, setSubmissionType] = useState<PublicSubmissionType | "">("");
   const [url, setUrl] = useState("");


### PR DESCRIPTION
## Summary

- replace the tool-only form with an accessible binary `tool | resource` submission flow
- require anonymous name and GitHub attribution on the server and in the UI
- resolve signed-in attribution only from verified Supabase identity data, persist the user ID, and expose trusted GitHub identity through `whoami`
- prevent forged client auth context and preserve verified attribution precedence across tool and resource storage
- wait for auth resolution before rendering attribution requirements
- route submissions through the typed `/api/submissions` client while retaining `/api/tools` compatibility
- align navigation, page copy, privacy text, README, architecture, component tests, and Chromium ARIA snapshots

## Trust model

Bearer authentication is verified server-side. GitHub attribution is considered verified only when it comes from GitHub identity data; editable user metadata is not trusted. Anonymous callers must provide attribution, and client-supplied `authenticatedUser` data is rejected by the strict Valibot contract.

## Checks

- focused and full Vitest suites passed
- full Playwright Chromium suite passed
- typecheck, ESLint, Stylelint, Prettier, and `git diff --check` passed
- independent review completed after all auth, loading-state, endpoint, storage, and architecture feedback

Closes #156.
Closes #115.
