### PR TITLE
Add durable submission rate limiting

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -30,7 +30,7 @@ CLOUDINARY_API_SECRET=op(op://dev/makerbench-cloudinary/api-secret)
 BROWSERLESS_API_KEY=op(op://dev/makerbench-browserless/api-key)
 
 # Public submission rate limiting (server-only)
-# @type=string(minLength=32) @sensitive
+# @type=string(isLength=64,matches=/^[0-9A-Fa-f]{64}$/) @sensitive
 SUBMISSION_RATE_LIMIT_SECRET=
 # @required
 SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS=5

--- a/.env.schema
+++ b/.env.schema
@@ -30,8 +30,8 @@ CLOUDINARY_API_SECRET=op(op://dev/makerbench-cloudinary/api-secret)
 BROWSERLESS_API_KEY=op(op://dev/makerbench-browserless/api-key)
 
 # Public submission rate limiting (server-only)
-# Configure SUBMISSION_RATE_LIMIT_SECRET through Netlify or a secure local
-# environment source. It is intentionally not assigned in this checked-in file.
+# @type=string(minLength=32) @sensitive @required
+SUBMISSION_RATE_LIMIT_SECRET=
 # @required
 SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS=5
 # @required

--- a/.env.schema
+++ b/.env.schema
@@ -28,3 +28,11 @@ CLOUDINARY_API_SECRET=op(op://dev/makerbench-cloudinary/api-secret)
 # Browserless (screenshot service)
 # @sensitive @required
 BROWSERLESS_API_KEY=op(op://dev/makerbench-browserless/api-key)
+
+# Public submission rate limiting (server-only)
+# Configure SUBMISSION_RATE_LIMIT_SECRET through Netlify or a secure local
+# environment source. It is intentionally not assigned in this checked-in file.
+# @required
+SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS=5
+# @required
+SUBMISSION_RATE_LIMIT_WINDOW_SECONDS=3600

--- a/.env.schema
+++ b/.env.schema
@@ -30,7 +30,7 @@ CLOUDINARY_API_SECRET=op(op://dev/makerbench-cloudinary/api-secret)
 BROWSERLESS_API_KEY=op(op://dev/makerbench-browserless/api-key)
 
 # Public submission rate limiting (server-only)
-# @type=string(minLength=32) @sensitive @required
+# @type=string(minLength=32) @sensitive
 SUBMISSION_RATE_LIMIT_SECRET=
 # @required
 SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS=5

--- a/architecture.md
+++ b/architecture.md
@@ -519,10 +519,10 @@ environment settings. Key variables:
 
 Server-side functions read secrets via `Netlify.env.get()`. Client-visible vars use the `VITE_` prefix and are bundled by Vite.
 The blank `SUBMISSION_RATE_LIMIT_SECRET=` value in `.env.schema` is an
-intentional Varlock declaration with no checked-in default. Because it is
-marked required and sensitive, callers must provide it through the external
-process environment or a secure Varlock/Netlify source before commands that
-load the schema; Varlock reports a configuration error when it is absent.
+intentional sensitive Varlock declaration with no checked-in default. It is
+optional during frontend builds, but the Netlify submission function requires
+it at runtime and fails closed with a generic 503 when it is absent or invalid.
+Provide it through a secure external process environment or Netlify setting.
 
 ## Current Gaps and Roadmap
 

--- a/architecture.md
+++ b/architecture.md
@@ -243,11 +243,24 @@ The database stores only `HMAC-SHA-256(secret, "user:<id>" | "ip:<address>")`,
 the window start, and an attempt count. It never stores a raw IP or submission
 payload. The counter update is one atomic Postgres `INSERT ... ON CONFLICT ...
 WHERE` statement, so concurrent requests cannot exceed the configured limit.
+Before admission, a separate cleanup statement locks and deletes at most 100
+expired rows whose last update is older than 30 days. It uses the `updated_at`
+retention index and also checks that the rate-limit window has expired, so it
+cannot delete active windows. Cleanup remains separate from the atomic
+admission boundary; a failure in either statement fails closed with a generic
+503 response.
+
 The table has RLS and no `anon` or `authenticated` privileges; only trusted
 server-side database access can use it. This reduces privacy exposure but does
 not make IP-based limits a perfect identity signal (shared NATs and rotating
 addresses remain a tradeoff). Rotate the HMAC secret only deliberately: doing
-so resets anonymous rate-limit continuity.
+so changes every HMAC key and resets continuity for both authenticated user and
+anonymous IP identities.
+
+The SQL concurrency and expiry tests execute the rendered production queries
+against PGlite, an embedded WASM PostgreSQL build. This verifies PostgreSQL SQL
+semantics and persisted counts, but its single-process executor does not model
+network latency, connection-pool scheduling, or multiple server processes.
 
 ### External service integrations
 
@@ -505,6 +518,11 @@ environment settings. Key variables:
 | `SENTRY_DSN`                           | Server only     | Optional error tracking                      |
 
 Server-side functions read secrets via `Netlify.env.get()`. Client-visible vars use the `VITE_` prefix and are bundled by Vite.
+The blank `SUBMISSION_RATE_LIMIT_SECRET=` value in `.env.schema` is an
+intentional Varlock declaration with no checked-in default. Because it is
+marked required and sensitive, callers must provide it through the external
+process environment or a secure Varlock/Netlify source before commands that
+load the schema; Varlock reports a configuration error when it is absent.
 
 ## Current Gaps and Roadmap
 

--- a/architecture.md
+++ b/architecture.md
@@ -257,10 +257,11 @@ addresses remain a tradeoff). Rotate the HMAC secret only deliberately: doing
 so changes every HMAC key and resets continuity for both authenticated user and
 anonymous IP identities.
 
-The SQL concurrency and expiry tests execute the rendered production queries
-against PGlite, an embedded WASM PostgreSQL build. This verifies PostgreSQL SQL
-semantics and persisted counts, but its single-process executor does not model
-network latency, connection-pool scheduling, or multiple server processes.
+The serialized admission and expiry tests execute the rendered production
+queries against PGlite, an embedded WASM PostgreSQL build. This verifies the
+admission statement's serialized PostgreSQL semantics and persisted counts,
+but it does not test concurrent connections, network latency, connection-pool
+scheduling, or multiple server processes.
 
 ### External service integrations
 
@@ -512,7 +513,7 @@ environment settings. Key variables:
 | `VITE_SUPABASE_ANON_KEY`               | Client + server | Supabase anon key (JWT verification)         |
 | `CLOUDINARY_*`                         | Server only     | Screenshot upload                            |
 | `BROWSERLESS_API_KEY`                  | Server only     | Screenshot capture                           |
-| `SUBMISSION_RATE_LIMIT_SECRET`         | Server only     | HMAC key, at least 32 characters             |
+| `SUBMISSION_RATE_LIMIT_SECRET`         | Server only     | 64-character hexadecimal HMAC key            |
 | `SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS`   | Server only     | Attempts permitted in one fixed window       |
 | `SUBMISSION_RATE_LIMIT_WINDOW_SECONDS` | Server only     | Fixed-window duration in seconds             |
 | `SENTRY_DSN`                           | Server only     | Optional error tracking                      |
@@ -521,7 +522,8 @@ Server-side functions read secrets via `Netlify.env.get()`. Client-visible vars 
 The blank `SUBMISSION_RATE_LIMIT_SECRET=` value in `.env.schema` is an
 intentional sensitive Varlock declaration with no checked-in default. It is
 optional during frontend builds, but the Netlify submission function requires
-it at runtime and fails closed with a generic 503 when it is absent or invalid.
+it at runtime, validates it as exactly 64 hexadecimal characters, and fails
+closed with a generic 503 when it is absent or invalid.
 Provide it through a secure external process environment or Netlify setting.
 
 ## Current Gaps and Roadmap

--- a/architecture.md
+++ b/architecture.md
@@ -229,6 +229,26 @@ The server always resolves attribution authoritatively. Verified display-name an
 
 Functions call `validate*()` helpers, and the frontend reuses the shared schemas for form validation. Client validation improves feedback but does not replace server enforcement.
 
+### Public submission rate limiting
+
+`/api/submissions` and legacy `/api/tools` use the same durable PostgreSQL
+fixed-window limiter before URL resolution, metadata fetches, screenshots, or
+moderation-row creation. Authenticated requests are keyed by the verified
+Supabase user ID. Anonymous requests use Netlify Functions
+[`context.ip`](https://docs.netlify.com/build/functions/api/#ip), which Netlify
+documents as the client IP address; request headers and client-provided
+fingerprints are deliberately ignored.
+
+The database stores only `HMAC-SHA-256(secret, "user:<id>" | "ip:<address>")`,
+the window start, and an attempt count. It never stores a raw IP or submission
+payload. The counter update is one atomic Postgres `INSERT ... ON CONFLICT ...
+WHERE` statement, so concurrent requests cannot exceed the configured limit.
+The table has RLS and no `anon` or `authenticated` privileges; only trusted
+server-side database access can use it. This reduces privacy exposure but does
+not make IP-based limits a perfect identity signal (shared NATs and rotating
+addresses remain a tradeoff). Rotate the HMAC secret only deliberately: doing
+so resets anonymous rate-limit continuity.
+
 ### External service integrations
 
 **Metadata extraction** (`src/lib/services/metadata.ts`):
@@ -319,17 +339,18 @@ erDiagram
     }
 ```
 
-| Table                | Purpose                                                          |
-| -------------------- | ---------------------------------------------------------------- |
-| `resources`          | Canonical URL identity shared across all listing types           |
-| `tool_listings`      | Public tool submissions with moderation status and preview image |
-| `bookmarks`          | Per-user personal bookmarks (private library)                    |
-| `public_listings`    | Moderated resource submissions and migrated community resources  |
-| `public_stacks`      | Curated multi-item resource stacks                               |
-| `public_stack_items` | Items within a public stack                                      |
-| `user_roles`         | Admin role assignments                                           |
-| `user_preferences`   | User settings (e.g. highlight color)                             |
-| `auth.users`         | Supabase-managed auth users (referenced, not owned)              |
+| Table                           | Purpose                                                          |
+| ------------------------------- | ---------------------------------------------------------------- |
+| `resources`                     | Canonical URL identity shared across all listing types           |
+| `tool_listings`                 | Public tool submissions with moderation status and preview image |
+| `bookmarks`                     | Per-user personal bookmarks (private library)                    |
+| `public_listings`               | Moderated resource submissions and migrated community resources  |
+| `public_stacks`                 | Curated multi-item resource stacks                               |
+| `public_stack_items`            | Items within a public stack                                      |
+| `user_roles`                    | Admin role assignments                                           |
+| `user_preferences`              | User settings (e.g. highlight color)                             |
+| `public_submission_rate_limits` | Server-only HMAC-keyed submission throttle state                 |
+| `auth.users`                    | Supabase-managed auth users (referenced, not owned)              |
 
 `public_listings.content_kind` retains `article | resource` for migrated and existing rows. New public submission input is binary `tool | resource`; articles, guides, and other article-like links are submitted as `resource`, not as a third input type.
 
@@ -468,16 +489,20 @@ Database migrations are applied separately via `pnpm db:migrate` against the tar
 
 ## Environment Variables
 
-Defined in `.env.schema` (Varlock). Key variables:
+Server configuration is defined in `.env.schema` (Varlock) and Netlify
+environment settings. Key variables:
 
-| Variable                 | Scope           | Purpose                                      |
-| ------------------------ | --------------- | -------------------------------------------- |
-| `SUPABASE_DATABASE_URL`  | Server only     | Postgres connection (pooler URL recommended) |
-| `VITE_SUPABASE_URL`      | Client + server | Supabase project URL                         |
-| `VITE_SUPABASE_ANON_KEY` | Client + server | Supabase anon key (JWT verification)         |
-| `CLOUDINARY_*`           | Server only     | Screenshot upload                            |
-| `BROWSERLESS_API_KEY`    | Server only     | Screenshot capture                           |
-| `SENTRY_DSN`             | Server only     | Optional error tracking                      |
+| Variable                               | Scope           | Purpose                                      |
+| -------------------------------------- | --------------- | -------------------------------------------- |
+| `SUPABASE_DATABASE_URL`                | Server only     | Postgres connection (pooler URL recommended) |
+| `VITE_SUPABASE_URL`                    | Client + server | Supabase project URL                         |
+| `VITE_SUPABASE_ANON_KEY`               | Client + server | Supabase anon key (JWT verification)         |
+| `CLOUDINARY_*`                         | Server only     | Screenshot upload                            |
+| `BROWSERLESS_API_KEY`                  | Server only     | Screenshot capture                           |
+| `SUBMISSION_RATE_LIMIT_SECRET`         | Server only     | HMAC key, at least 32 characters             |
+| `SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS`   | Server only     | Attempts permitted in one fixed window       |
+| `SUBMISSION_RATE_LIMIT_WINDOW_SECONDS` | Server only     | Fixed-window duration in seconds             |
+| `SENTRY_DSN`                           | Server only     | Optional error tracking                      |
 
 Server-side functions read secrets via `Netlify.env.get()`. Client-visible vars use the `VITE_` prefix and are bundled by Vite.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -52,10 +52,12 @@ The required names are:
 `SENTRY_DSN` is a separate optional setting read by the Functions when
 configured; it is not required by `.env.schema`. The `VITE_` variables are
 exposed to the browser by Vite; the database and service credentials are
-server-side values. `SUBMISSION_RATE_LIMIT_SECRET` is intentionally supplied
-through a secure local environment source rather than assigned in
-`.env.schema`; its tuning values are defined there. Netlify Functions read
-their values from `Netlify.env`.
+server-side values. `.env.schema` declares `SUBMISSION_RATE_LIMIT_SECRET` with
+an intentionally blank value, `@required`, and `@sensitive`. In Varlock this
+means there is no checked-in default: export it from a secure external process
+environment or configure a secure Varlock source before running commands that
+load the schema. Missing values fail Varlock configuration validation. Netlify
+Functions read runtime values from `Netlify.env`.
 
 ## 3. Apply Supabase migrations
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -45,11 +45,17 @@ The required names are:
 - `CLOUDINARY_API_KEY`
 - `CLOUDINARY_API_SECRET`
 - `BROWSERLESS_API_KEY`
+- `SUBMISSION_RATE_LIMIT_SECRET` - a server-only random secret of at least 32 characters
+- `SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS` - positive integer, at most 1000
+- `SUBMISSION_RATE_LIMIT_WINDOW_SECONDS` - positive integer, at most 86400
 
 `SENTRY_DSN` is a separate optional setting read by the Functions when
 configured; it is not required by `.env.schema`. The `VITE_` variables are
 exposed to the browser by Vite; the database and service credentials are
-server-side values. Netlify Functions read their values from `Netlify.env`.
+server-side values. `SUBMISSION_RATE_LIMIT_SECRET` is intentionally supplied
+through a secure local environment source rather than assigned in
+`.env.schema`; its tuning values are defined there. Netlify Functions read
+their values from `Netlify.env`.
 
 ## 3. Apply Supabase migrations
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -53,11 +53,11 @@ The required names are:
 configured; it is not required by `.env.schema`. The `VITE_` variables are
 exposed to the browser by Vite; the database and service credentials are
 server-side values. `.env.schema` declares `SUBMISSION_RATE_LIMIT_SECRET` with
-an intentionally blank value, `@required`, and `@sensitive`. In Varlock this
-means there is no checked-in default: export it from a secure external process
-environment or configure a secure Varlock source before running commands that
-load the schema. Missing values fail Varlock configuration validation. Netlify
-Functions read runtime values from `Netlify.env`.
+an intentionally blank value and `@sensitive`. This keeps frontend-only builds
+independent of the server runtime secret while providing no checked-in default.
+Export it from a secure external process environment or configure a secure
+Varlock source before exercising submissions. The Netlify Function requires it
+at runtime and fails closed when it is absent or invalid.
 
 ## 3. Apply Supabase migrations
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -45,7 +45,7 @@ The required names are:
 - `CLOUDINARY_API_KEY`
 - `CLOUDINARY_API_SECRET`
 - `BROWSERLESS_API_KEY`
-- `SUBMISSION_RATE_LIMIT_SECRET` - a server-only random secret of at least 32 characters
+- `SUBMISSION_RATE_LIMIT_SECRET` - a server-only secret of exactly 64 hexadecimal characters
 - `SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS` - positive integer, at most 1000
 - `SUBMISSION_RATE_LIMIT_WINDOW_SECONDS` - positive integer, at most 86400
 
@@ -57,7 +57,9 @@ an intentionally blank value and `@sensitive`. This keeps frontend-only builds
 independent of the server runtime secret while providing no checked-in default.
 Export it from a secure external process environment or configure a secure
 Varlock source before exercising submissions. The Netlify Function requires it
-at runtime and fails closed when it is absent or invalid.
+at runtime and fails closed when it is absent, is not exactly 64 characters,
+or contains non-hexadecimal characters. Generate a suitable value with
+`openssl rand -hex 32`.
 
 ## 3. Apply Supabase migrations
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -55,7 +55,7 @@ context that needs them:
 - `CLOUDINARY_API_KEY`
 - `CLOUDINARY_API_SECRET`
 - `BROWSERLESS_API_KEY`
-- `SUBMISSION_RATE_LIMIT_SECRET` - server-only HMAC secret (32+ characters)
+- `SUBMISSION_RATE_LIMIT_SECRET` - server-only HMAC secret (exactly 64 hexadecimal characters)
 - `SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS` - positive integer, at most 1000
 - `SUBMISSION_RATE_LIMIT_WINDOW_SECONDS` - positive integer, at most 86400
 - `SENTRY_DSN` (optional)
@@ -70,7 +70,10 @@ The blank `SUBMISSION_RATE_LIMIT_SECRET` assignment there is deliberate: it
 declares a sensitive external value without a repository default while allowing
 frontend-only builds to run. Configure it in Netlify before enabling public
 submissions; the submission Function requires it at runtime and fails closed
-with a generic 503 when it is absent or invalid.
+with a generic 503 when it is absent, is not exactly 64 characters, or contains
+non-hexadecimal characters. Generate a suitable value with
+`openssl rand -hex 32` and store it only in Netlify's secure environment
+settings.
 `SENTRY_DSN` is a separate optional Netlify runtime setting. Do not configure
 legacy database variables for the active deployment.
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -66,6 +66,10 @@ must not be committed or placed in frontend source. Netlify Functions read
 runtime values through `Netlify.env`; Netlify supplies `CONTEXT` automatically.
 
 Use the required variable names in [`.env.schema`](../.env.schema).
+The blank `SUBMISSION_RATE_LIMIT_SECRET` assignment there is deliberate: it
+declares a required sensitive external value without a repository default.
+Configure it in Netlify for every deploy context before builds or Functions
+run; Varlock validation fails when it is absent.
 `SENTRY_DSN` is a separate optional Netlify runtime setting. Do not configure
 legacy database variables for the active deployment.
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -67,9 +67,10 @@ runtime values through `Netlify.env`; Netlify supplies `CONTEXT` automatically.
 
 Use the required variable names in [`.env.schema`](../.env.schema).
 The blank `SUBMISSION_RATE_LIMIT_SECRET` assignment there is deliberate: it
-declares a required sensitive external value without a repository default.
-Configure it in Netlify for every deploy context before builds or Functions
-run; Varlock validation fails when it is absent.
+declares a sensitive external value without a repository default while allowing
+frontend-only builds to run. Configure it in Netlify before enabling public
+submissions; the submission Function requires it at runtime and fails closed
+with a generic 503 when it is absent or invalid.
 `SENTRY_DSN` is a separate optional Netlify runtime setting. Do not configure
 legacy database variables for the active deployment.
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -55,6 +55,9 @@ context that needs them:
 - `CLOUDINARY_API_KEY`
 - `CLOUDINARY_API_SECRET`
 - `BROWSERLESS_API_KEY`
+- `SUBMISSION_RATE_LIMIT_SECRET` - server-only HMAC secret (32+ characters)
+- `SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS` - positive integer, at most 1000
+- `SUBMISSION_RATE_LIMIT_WINDOW_SECONDS` - positive integer, at most 86400
 - `SENTRY_DSN` (optional)
 
 The `VITE_` variables must be available during the frontend build and to the

--- a/migrations/postgres/0008_flat_proteus.sql
+++ b/migrations/postgres/0008_flat_proteus.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "public_submission_rate_limits" (
+	"key_hash" text PRIMARY KEY NOT NULL,
+	"window_started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"attempt_count" integer DEFAULT 1 NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "public_submission_rate_limits_attempt_count_check" CHECK ("public_submission_rate_limits"."attempt_count" > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "public_submission_rate_limits" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON TABLE public.public_submission_rate_limits
+  FROM anon, authenticated;

--- a/migrations/postgres/0009_rich_supernaut.sql
+++ b/migrations/postgres/0009_rich_supernaut.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "idx_public_submission_rate_limits_updated_at" ON "public_submission_rate_limits" USING btree ("updated_at");

--- a/migrations/postgres/meta/0008_snapshot.json
+++ b/migrations/postgres/meta/0008_snapshot.json
@@ -1,0 +1,1456 @@
+{
+  "id": "96a19c08-3d02-43d9-a13b-1bf1089901a6",
+  "prevId": "ba7c84fe-b6ba-4737-af0e-8148b91f8327",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_override": {
+          "name": "title_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_override": {
+          "name": "description_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookmarks_user_created": {
+          "name": "idx_bookmarks_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_parent": {
+          "name": "idx_bookmarks_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_resource": {
+          "name": "idx_bookmarks_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_user_resource": {
+          "name": "unique_user_resource",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_resource_id_resources_id_fk": {
+          "name": "bookmarks_resource_id_resources_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_parent_id_bookmarks_id_fk": {
+          "name": "bookmarks_parent_id_bookmarks_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_listings": {
+      "name": "public_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_by_bookmark_id": {
+          "name": "submitted_by_bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_github_url": {
+          "name": "submitter_github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resource'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_public_listings_status": {
+          "name": "idx_public_listings_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_listings_tags": {
+          "name": "idx_public_listings_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_listings_search": {
+          "name": "idx_public_listings_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_listings_resource": {
+          "name": "idx_public_listings_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_public_listing_resource": {
+          "name": "unique_public_listing_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_listings_resource_id_resources_id_fk": {
+          "name": "public_listings_resource_id_resources_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_listings_submitted_by_user_id_users_id_fk": {
+          "name": "public_listings_submitted_by_user_id_users_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_listings_submitted_by_bookmark_id_bookmarks_id_fk": {
+          "name": "public_listings_submitted_by_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["submitted_by_bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "public_listings_reviewed_by_users_id_fk": {
+          "name": "public_listings_reviewed_by_users_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "public_listings_content_kind_check": {
+          "name": "public_listings_content_kind_check",
+          "value": "\"public_listings\".\"content_kind\" in ('article', 'resource')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.public_stack_items": {
+      "name": "public_stack_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public_stack_id": {
+          "name": "public_stack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookmark_id": {
+          "name": "bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_public_listing_id": {
+          "name": "source_public_listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_public_stack_item_bookmark": {
+          "name": "unique_public_stack_item_bookmark",
+          "columns": [
+            {
+              "expression": "bookmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_public_stack_resource": {
+          "name": "unique_public_stack_resource",
+          "columns": [
+            {
+              "expression": "public_stack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_status": {
+          "name": "idx_public_stack_items_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_stack": {
+          "name": "idx_public_stack_items_stack",
+          "columns": [
+            {
+              "expression": "public_stack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_tags": {
+          "name": "idx_public_stack_items_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stack_items_search": {
+          "name": "idx_public_stack_items_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stack_items_resource": {
+          "name": "idx_public_stack_items_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_stack_items_public_stack_id_public_stacks_id_fk": {
+          "name": "public_stack_items_public_stack_id_public_stacks_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "public_stacks",
+          "columnsFrom": ["public_stack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_bookmark_id_bookmarks_id_fk": {
+          "name": "public_stack_items_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_resource_id_resources_id_fk": {
+          "name": "public_stack_items_resource_id_resources_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_source_public_listing_id_public_listings_id_fk": {
+          "name": "public_stack_items_source_public_listing_id_public_listings_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "public_listings",
+          "columnsFrom": ["source_public_listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_reviewed_by_users_id_fk": {
+          "name": "public_stack_items_reviewed_by_users_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_stacks": {
+      "name": "public_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root_bookmark_id": {
+          "name": "root_bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_public_stack_root": {
+          "name": "unique_public_stack_root",
+          "columns": [
+            {
+              "expression": "root_bookmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_status": {
+          "name": "idx_public_stacks_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_tags": {
+          "name": "idx_public_stacks_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stacks_search": {
+          "name": "idx_public_stacks_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stacks_owner": {
+          "name": "idx_public_stacks_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_resource": {
+          "name": "idx_public_stacks_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_stacks_root_bookmark_id_bookmarks_id_fk": {
+          "name": "public_stacks_root_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["root_bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_resource_id_resources_id_fk": {
+          "name": "public_stacks_resource_id_resources_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_owner_user_id_users_id_fk": {
+          "name": "public_stacks_owner_user_id_users_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_reviewed_by_users_id_fk": {
+          "name": "public_stacks_reviewed_by_users_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_submission_rate_limits": {
+      "name": "public_submission_rate_limits",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "public_submission_rate_limits_attempt_count_check": {
+          "name": "public_submission_rate_limits_attempt_count_check",
+          "value": "\"public_submission_rate_limits\".\"attempt_count\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resources_normalized_url_unique": {
+          "name": "resources_normalized_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["normalized_url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tool_listings": {
+      "name": "tool_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_source": {
+          "name": "image_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_github_url": {
+          "name": "submitter_github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_listings_status_created": {
+          "name": "idx_tool_listings_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_tool_listing_resource": {
+          "name": "unique_tool_listing_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tool_listings_resource_id_resources_id_fk": {
+          "name": "tool_listings_resource_id_resources_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_listings_submitted_by_user_id_users_id_fk": {
+          "name": "tool_listings_submitted_by_user_id_users_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_listings_reviewed_by_users_id_fk": {
+          "name": "tool_listings_reviewed_by_users_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "highlight_color": {
+          "name": "highlight_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_role": {
+          "name": "unique_user_role",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/postgres/meta/0009_snapshot.json
+++ b/migrations/postgres/meta/0009_snapshot.json
@@ -1,0 +1,1472 @@
+{
+  "id": "500f714f-2e99-4885-b0c4-bc6f14084ed7",
+  "prevId": "96a19c08-3d02-43d9-a13b-1bf1089901a6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_override": {
+          "name": "title_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_override": {
+          "name": "description_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookmarks_user_created": {
+          "name": "idx_bookmarks_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_parent": {
+          "name": "idx_bookmarks_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_resource": {
+          "name": "idx_bookmarks_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_user_resource": {
+          "name": "unique_user_resource",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_resource_id_resources_id_fk": {
+          "name": "bookmarks_resource_id_resources_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_parent_id_bookmarks_id_fk": {
+          "name": "bookmarks_parent_id_bookmarks_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_listings": {
+      "name": "public_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_by_bookmark_id": {
+          "name": "submitted_by_bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_github_url": {
+          "name": "submitter_github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resource'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_public_listings_status": {
+          "name": "idx_public_listings_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_listings_tags": {
+          "name": "idx_public_listings_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_listings_search": {
+          "name": "idx_public_listings_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_listings_resource": {
+          "name": "idx_public_listings_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_public_listing_resource": {
+          "name": "unique_public_listing_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_listings_resource_id_resources_id_fk": {
+          "name": "public_listings_resource_id_resources_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_listings_submitted_by_user_id_users_id_fk": {
+          "name": "public_listings_submitted_by_user_id_users_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_listings_submitted_by_bookmark_id_bookmarks_id_fk": {
+          "name": "public_listings_submitted_by_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["submitted_by_bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "public_listings_reviewed_by_users_id_fk": {
+          "name": "public_listings_reviewed_by_users_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "public_listings_content_kind_check": {
+          "name": "public_listings_content_kind_check",
+          "value": "\"public_listings\".\"content_kind\" in ('article', 'resource')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.public_stack_items": {
+      "name": "public_stack_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public_stack_id": {
+          "name": "public_stack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookmark_id": {
+          "name": "bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_public_listing_id": {
+          "name": "source_public_listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_public_stack_item_bookmark": {
+          "name": "unique_public_stack_item_bookmark",
+          "columns": [
+            {
+              "expression": "bookmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_public_stack_resource": {
+          "name": "unique_public_stack_resource",
+          "columns": [
+            {
+              "expression": "public_stack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_status": {
+          "name": "idx_public_stack_items_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_stack": {
+          "name": "idx_public_stack_items_stack",
+          "columns": [
+            {
+              "expression": "public_stack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_tags": {
+          "name": "idx_public_stack_items_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stack_items_search": {
+          "name": "idx_public_stack_items_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stack_items_resource": {
+          "name": "idx_public_stack_items_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_stack_items_public_stack_id_public_stacks_id_fk": {
+          "name": "public_stack_items_public_stack_id_public_stacks_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "public_stacks",
+          "columnsFrom": ["public_stack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_bookmark_id_bookmarks_id_fk": {
+          "name": "public_stack_items_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_resource_id_resources_id_fk": {
+          "name": "public_stack_items_resource_id_resources_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_source_public_listing_id_public_listings_id_fk": {
+          "name": "public_stack_items_source_public_listing_id_public_listings_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "public_listings",
+          "columnsFrom": ["source_public_listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_reviewed_by_users_id_fk": {
+          "name": "public_stack_items_reviewed_by_users_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_stacks": {
+      "name": "public_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root_bookmark_id": {
+          "name": "root_bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_public_stack_root": {
+          "name": "unique_public_stack_root",
+          "columns": [
+            {
+              "expression": "root_bookmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_status": {
+          "name": "idx_public_stacks_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_tags": {
+          "name": "idx_public_stacks_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stacks_search": {
+          "name": "idx_public_stacks_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stacks_owner": {
+          "name": "idx_public_stacks_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_resource": {
+          "name": "idx_public_stacks_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_stacks_root_bookmark_id_bookmarks_id_fk": {
+          "name": "public_stacks_root_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["root_bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_resource_id_resources_id_fk": {
+          "name": "public_stacks_resource_id_resources_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_owner_user_id_users_id_fk": {
+          "name": "public_stacks_owner_user_id_users_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_reviewed_by_users_id_fk": {
+          "name": "public_stacks_reviewed_by_users_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_submission_rate_limits": {
+      "name": "public_submission_rate_limits",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_public_submission_rate_limits_updated_at": {
+          "name": "idx_public_submission_rate_limits_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "public_submission_rate_limits_attempt_count_check": {
+          "name": "public_submission_rate_limits_attempt_count_check",
+          "value": "\"public_submission_rate_limits\".\"attempt_count\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resources_normalized_url_unique": {
+          "name": "resources_normalized_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["normalized_url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tool_listings": {
+      "name": "tool_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_source": {
+          "name": "image_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_github_url": {
+          "name": "submitter_github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_listings_status_created": {
+          "name": "idx_tool_listings_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_tool_listing_resource": {
+          "name": "unique_tool_listing_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tool_listings_resource_id_resources_id_fk": {
+          "name": "tool_listings_resource_id_resources_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_listings_submitted_by_user_id_users_id_fk": {
+          "name": "tool_listings_submitted_by_user_id_users_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_listings_reviewed_by_users_id_fk": {
+          "name": "tool_listings_reviewed_by_users_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "highlight_color": {
+          "name": "highlight_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_role": {
+          "name": "unique_user_role",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/postgres/meta/_journal.json
+++ b/migrations/postgres/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1783802614827,
       "tag": "0008_flat_proteus",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1783804190694,
+      "tag": "0009_rich_supernaut",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/postgres/meta/_journal.json
+++ b/migrations/postgres/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1783799427633,
       "tag": "0007_kind_sentinel",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1783802614827,
+      "tag": "0008_flat_proteus",
+      "breakpoints": true
     }
   ]
 }

--- a/netlify/functions/__tests__/process-tool.test.ts
+++ b/netlify/functions/__tests__/process-tool.test.ts
@@ -79,6 +79,7 @@ function createMockContext(): Context {
  */
 function createMockDb() {
   const mockDb = {
+    execute: vi.fn().mockResolvedValue({ rows: [{ attempt_count: 1 }] }),
     select: vi.fn().mockReturnThis(),
     from: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
@@ -291,6 +292,29 @@ describe("process-tool", () => {
       expect(body.details?.type).toContain(
         "/api/tools only accepts tool submissions",
       );
+    });
+
+    it("rejects throttled tool submissions before metadata processing", async () => {
+      mockDb.execute.mockResolvedValueOnce({ rows: [] });
+      const req = new Request("https://test.com/api/tools", {
+        method: "POST",
+        body: JSON.stringify({
+          type: "tool",
+          url: "https://example.com/tool",
+          tags: ["test"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const res = await processTool(req, mockContext);
+
+      expect(res.status).toBe(429);
+      await expect(res.json()).resolves.toEqual({
+        success: false,
+        error: "Too many submission attempts. Please try again later.",
+      });
+      expect(extractMetadata).not.toHaveBeenCalled();
+      expect(mockDb.insert).not.toHaveBeenCalled();
     });
 
     it("returns generic 503 when required env vars are missing", async () => {

--- a/netlify/functions/__tests__/process-tool.test.ts
+++ b/netlify/functions/__tests__/process-tool.test.ts
@@ -23,6 +23,12 @@ vi.mock("../lib/auth", async (importOriginal) => {
   };
 });
 
+vi.mock("../lib/sentry", () => ({
+  initSentry: vi.fn(),
+  captureError: vi.fn(),
+  flushSentry: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Mock external services
 vi.mock("../../../src/lib/services/metadata", () => ({
   extractMetadata: vi.fn(),
@@ -295,7 +301,9 @@ describe("process-tool", () => {
     });
 
     it("rejects throttled tool submissions before metadata processing", async () => {
-      mockDb.execute.mockResolvedValueOnce({ rows: [] });
+      mockDb.execute
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
       const req = new Request("https://test.com/api/tools", {
         method: "POST",
         body: JSON.stringify({
@@ -314,6 +322,32 @@ describe("process-tool", () => {
         error: "Too many submission attempts. Please try again later.",
       });
       expect(extractMetadata).not.toHaveBeenCalled();
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("fails closed on limiter datastore errors without creating tool rows", async () => {
+      mockDb.execute.mockRejectedValueOnce(
+        new Error("rate limit datastore unavailable"),
+      );
+      const req = new Request("https://test.com/api/tools", {
+        method: "POST",
+        body: JSON.stringify({
+          type: "tool",
+          url: "https://example.com/tool",
+          tags: ["test"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const res = await processTool(req, mockContext);
+
+      expect(res.status).toBe(503);
+      await expect(res.json()).resolves.toEqual({
+        success: false,
+        error: "Service temporarily unavailable",
+      });
+      expect(extractMetadata).not.toHaveBeenCalled();
+      expect(captureScreenshot).not.toHaveBeenCalled();
       expect(mockDb.insert).not.toHaveBeenCalled();
     });
 

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -205,6 +205,8 @@ describe("public-submissions", () => {
           type: "resource",
           url: "https://example.com/header-spoof-test",
           tags: ["security"],
+          submitterName: "Ada",
+          submitterGithubUsername: "ada-lovelace",
         },
         undefined,
         {

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -45,9 +45,10 @@ import { lookup } from "node:dns/promises";
 import { captureScreenshot } from "../../../src/lib/services/screenshot";
 import { uploadScreenshot } from "../../../src/lib/services/cloudinary";
 import { extractMetadata } from "../../../src/lib/services/metadata";
+import { TEST_SUBMISSION_RATE_LIMIT_SECRET } from "../../../src/test/rate-limit-fixtures";
 import { createMockContext, getPgQuery } from "./test-utils";
 
-const RATE_LIMIT_SECRET = "test-submission-rate-limit-secret-1234567890";
+const RATE_LIMIT_SECRET = TEST_SUBMISSION_RATE_LIMIT_SECRET;
 
 interface SubmissionCreated {
   submittedItemId: string;

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -14,6 +14,12 @@ vi.mock("../lib/db", () => ({
   getDb: vi.fn(),
 }));
 
+vi.mock("../lib/sentry", () => ({
+  initSentry: vi.fn(),
+  captureError: vi.fn(),
+  flushSentry: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../../../src/lib/services/metadata", () => ({
   extractMetadata: vi.fn(),
 }));
@@ -33,11 +39,15 @@ vi.mock("node:dns/promises", () => ({
 import publicSubmissions from "../public-submissions.mts";
 import { verifyAuthenticatedUser } from "../lib/auth";
 import { getDb } from "../lib/db";
+import { captureError, flushSentry } from "../lib/sentry";
+import { createSubmissionRateLimitKey } from "../lib/submission-rate-limit";
 import { lookup } from "node:dns/promises";
 import { captureScreenshot } from "../../../src/lib/services/screenshot";
 import { uploadScreenshot } from "../../../src/lib/services/cloudinary";
 import { extractMetadata } from "../../../src/lib/services/metadata";
-import { createMockContext } from "./test-utils";
+import { createMockContext, getPgQuery } from "./test-utils";
+
+const RATE_LIMIT_SECRET = "test-submission-rate-limit-secret-1234567890";
 
 interface SubmissionCreated {
   submittedItemId: string;
@@ -57,12 +67,17 @@ function createMockDb() {
   };
 }
 
-function createSubmissionRequest(body: unknown, token?: string): Request {
+function createSubmissionRequest(
+  body: unknown,
+  token?: string,
+  additionalHeaders: Record<string, string> = {},
+): Request {
   return new Request("https://test.com/api/submissions", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...additionalHeaders,
     },
     body: JSON.stringify(body),
   });
@@ -169,6 +184,55 @@ describe("public-submissions", () => {
     expect(res.status).toBe(422);
     const body = (await res.json()) as ErrorResponse;
     expect(body.details?.authenticatedUser).toBeDefined();
+  });
+
+  it("ignores spoofed client IP headers and keys anonymous requests from context.ip", async () => {
+    const mockDb = createMockDb();
+    mockDb.execute
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ attempt_count: 1 }] });
+    mockDb.returning
+      .mockResolvedValueOnce([{ id: "11111111-1111-4111-8111-111111111111" }])
+      .mockResolvedValueOnce([{ id: "22222222-2222-4222-8222-222222222222" }]);
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+    const context = { ...createMockContext(), ip: "198.51.100.24" };
+
+    const res = await publicSubmissions(
+      createSubmissionRequest(
+        {
+          type: "resource",
+          url: "https://example.com/header-spoof-test",
+          tags: ["security"],
+        },
+        undefined,
+        {
+          "X-Forwarded-For": "203.0.113.99",
+          "X-Nf-Client-Connection-Ip": "203.0.113.100",
+        },
+      ),
+      context,
+    );
+
+    expect(res.status).toBe(201);
+    const admissionQuery = mockDb.execute.mock.calls
+      .map(([query]) => getPgQuery(query))
+      .find(({ sql }) => sql.includes("INSERT INTO"));
+    const contextKey = createSubmissionRateLimitKey(
+      { authenticated: null, clientIp: context.ip },
+      RATE_LIMIT_SECRET,
+    );
+    const spoofedKeys = ["203.0.113.99", "203.0.113.100"].map((clientIp) =>
+      createSubmissionRateLimitKey(
+        { authenticated: null, clientIp },
+        RATE_LIMIT_SECRET,
+      ),
+    );
+    expect(admissionQuery?.params).toContain(contextKey);
+    for (const spoofedKey of spoofedKeys) {
+      expect(admissionQuery?.params).not.toContain(spoofedKey);
+    }
   });
 
   it("stores signed-in attribution for public resource listings", async () => {
@@ -431,6 +495,48 @@ describe("public-submissions", () => {
       error: "Too many submission attempts. Please try again later.",
     });
     expect(body.error).not.toMatch(/5|3600|limit|window/i);
+    expect(extractMetadata).not.toHaveBeenCalled();
+    expect(captureScreenshot).not.toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on limiter datastore errors without logging identity material", async () => {
+    const mockDb = createMockDb();
+    mockDb.execute.mockRejectedValueOnce(
+      new Error("rate limit datastore unavailable"),
+    );
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+    const context = { ...createMockContext(), ip: "198.51.100.25" };
+
+    const res = await publicSubmissions(
+      createSubmissionRequest({
+        type: "resource",
+        url: "https://example.com/dependency-error",
+        tags: ["security"],
+      }),
+      context,
+    );
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({
+      success: false,
+      error: "Service temporarily unavailable",
+    });
+    expect(captureError).toHaveBeenCalledWith(expect.any(Error), {
+      function: "public-submissions",
+      dependency: "submission-rate-limit-store",
+    });
+    expect(flushSentry).toHaveBeenCalledOnce();
+    const captured = JSON.stringify(vi.mocked(captureError).mock.calls);
+    expect(captured).not.toContain(context.ip);
+    expect(captured).not.toContain(
+      createSubmissionRateLimitKey(
+        { authenticated: null, clientIp: context.ip },
+        RATE_LIMIT_SECRET,
+      ),
+    );
     expect(extractMetadata).not.toHaveBeenCalled();
     expect(captureScreenshot).not.toHaveBeenCalled();
     expect(mockDb.insert).not.toHaveBeenCalled();

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -48,6 +48,7 @@ interface SubmissionCreated {
 
 function createMockDb() {
   return {
+    execute: vi.fn().mockResolvedValue({ rows: [{ attempt_count: 1 }] }),
     insert: vi.fn().mockReturnThis(),
     values: vi.fn().mockReturnThis(),
     onConflictDoUpdate: vi.fn().mockReturnThis(),
@@ -305,6 +306,51 @@ describe("public-submissions", () => {
     expect(body.details?.tags).toBeDefined();
   });
 
+  it("fails closed with a generic response for missing or invalid limit configuration", async () => {
+    const originalGet = Netlify.env.get;
+    const request = createSubmissionRequest({
+      type: "resource",
+      url: "https://example.com/resource",
+      tags: ["css"],
+    });
+
+    try {
+      Netlify.env.get = vi.fn((key: string) =>
+        key === "SUBMISSION_RATE_LIMIT_SECRET" ? undefined : originalGet(key),
+      );
+      const missingResponse = await publicSubmissions(
+        request,
+        createMockContext(),
+      );
+      expect(missingResponse.status).toBe(503);
+      await expect(missingResponse.json()).resolves.toEqual({
+        success: false,
+        error: "Service temporarily unavailable",
+      });
+
+      Netlify.env.get = vi.fn((key: string) =>
+        key === "SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS"
+          ? "zero"
+          : originalGet(key),
+      );
+      const invalidResponse = await publicSubmissions(
+        createSubmissionRequest({
+          type: "resource",
+          url: "https://example.com/other-resource",
+          tags: ["css"],
+        }),
+        createMockContext(),
+      );
+      expect(invalidResponse.status).toBe(503);
+      await expect(invalidResponse.json()).resolves.toEqual({
+        success: false,
+        error: "Service temporarily unavailable",
+      });
+    } finally {
+      Netlify.env.get = originalGet;
+    }
+  });
+
   it("rejects article as a separate public submission type", async () => {
     const res = await publicSubmissions(
       createSubmissionRequest({
@@ -360,6 +406,34 @@ describe("public-submissions", () => {
     expect(res.status).toBe(409);
     const body = (await res.json()) as ErrorResponse;
     expect(body.error).toContain("already been submitted");
+  });
+
+  it("rejects throttled requests before metadata or moderation inserts", async () => {
+    const mockDb = createMockDb();
+    mockDb.execute.mockResolvedValue({ rows: [] });
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+
+    const res = await publicSubmissions(
+      createSubmissionRequest({
+        type: "resource",
+        url: "https://example.com/resource",
+        tags: ["css"],
+      }),
+      createMockContext(),
+    );
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as ErrorResponse;
+    expect(body).toEqual({
+      success: false,
+      error: "Too many submission attempts. Please try again later.",
+    });
+    expect(body.error).not.toMatch(/5|3600|limit|window/i);
+    expect(extractMetadata).not.toHaveBeenCalled();
+    expect(captureScreenshot).not.toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
   });
 
   it("rejects invalid bearer tokens instead of silently dropping attribution", async () => {

--- a/netlify/functions/lib/__tests__/env.test.ts
+++ b/netlify/functions/lib/__tests__/env.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getEnv } from "../env";
+
+describe("function environment access", () => {
+  it("reads only from the Netlify runtime environment", () => {
+    const key = "RATE_LIMIT_ENV_SOURCE_TEST";
+    process.env[key] = "process-value";
+    const get = vi.spyOn(Netlify.env, "get").mockReturnValue(undefined);
+
+    try {
+      expect(getEnv(key)).toBeUndefined();
+      expect(get).toHaveBeenCalledWith(key);
+    } finally {
+      delete process.env[key];
+      get.mockRestore();
+    }
+  });
+});

--- a/netlify/functions/lib/__tests__/responses.test.ts
+++ b/netlify/functions/lib/__tests__/responses.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dependencyUnavailable,
+  methodNotAllowed,
+  ok,
+  tooManyRequests,
+} from "../responses";
+
+describe("JSON response headers", () => {
+  it.each([
+    ["success", () => ok({ ready: true })],
+    ["rate limited", tooManyRequests],
+    ["dependency unavailable", dependencyUnavailable],
+    ["method not allowed", () => methodNotAllowed(["POST"])],
+  ])("sets nosniff for %s responses", (_name, createResponse) => {
+    const response = createResponse();
+
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+});

--- a/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
+++ b/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
@@ -150,8 +150,11 @@ describe("submission rate limit", () => {
     }
   });
 
-  it("declares the HMAC secret as required sensitive external Varlock config", () => {
+  it("declares the HMAC secret as sensitive external Varlock config", () => {
     expect(environmentSchema).toContain(
+      "# @type=string(minLength=32) @sensitive\nSUBMISSION_RATE_LIMIT_SECRET=",
+    );
+    expect(environmentSchema).not.toContain(
       "# @type=string(minLength=32) @sensitive @required\nSUBMISSION_RATE_LIMIT_SECRET=",
     );
   });

--- a/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
+++ b/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../db", () => ({
+  getDb: vi.fn(),
+}));
+
+import type { AuthenticatedUser } from "../auth";
+import { getDb } from "../db";
+import { InvalidEnvironmentError } from "../env";
+import {
+  consumeSubmissionRateLimit,
+  createSubmissionRateLimitKey,
+  getSubmissionRateLimitConfig,
+  type SubmissionRateLimitConfig,
+} from "../submission-rate-limit";
+import { getPgQuery } from "../../__tests__/test-utils";
+
+const config: SubmissionRateLimitConfig = {
+  secret: "test-submission-rate-limit-secret-1234567890",
+  maxAttempts: 5,
+  windowSeconds: 3600,
+};
+
+const rateLimitMigration = readFileSync(
+  new URL(
+    "../../../../migrations/postgres/0008_flat_proteus.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function setRateLimitEnvironment(
+  values: Partial<Record<string, string>>,
+): () => void {
+  const originalGet = Netlify.env.get;
+  Netlify.env.get = vi.fn((key: string) => values[key]);
+  return () => {
+    Netlify.env.get = originalGet;
+  };
+}
+
+describe("submission rate limit", () => {
+  it("allows the first and boundary attempts, then rejects an over-limit attempt", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ attempt_count: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ attempt_count: 5 }] })
+      .mockResolvedValueOnce({ rows: [] });
+    vi.mocked(getDb).mockReturnValue({ execute } as never);
+
+    await expect(consumeSubmissionRateLimit("first", config)).resolves.toBe(
+      true,
+    );
+    await expect(consumeSubmissionRateLimit("boundary", config)).resolves.toBe(
+      true,
+    );
+    await expect(consumeSubmissionRateLimit("rejected", config)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("uses separate HMAC keys for verified users and anonymous Netlify client IPs", () => {
+    const authenticated = {
+      user: { id: "11111111-1111-4111-8111-111111111111" },
+      isAdmin: false,
+    } as AuthenticatedUser;
+    const authenticatedKey = createSubmissionRateLimitKey(
+      { authenticated, clientIp: "203.0.113.1" },
+      config.secret,
+    );
+    const anonymousKey = createSubmissionRateLimitKey(
+      { authenticated: null, clientIp: "203.0.113.1" },
+      config.secret,
+    );
+
+    expect(authenticatedKey).toMatch(/^[a-f0-9]{64}$/);
+    expect(anonymousKey).toMatch(/^[a-f0-9]{64}$/);
+    expect(authenticatedKey).not.toBe(anonymousKey);
+    expect(anonymousKey).not.toContain("203.0.113.1");
+    expect(authenticatedKey).not.toContain(authenticated.user.id);
+  });
+
+  it("fails closed when anonymous Netlify context has no client IP", () => {
+    expect(() =>
+      createSubmissionRateLimitKey(
+        { authenticated: null, clientIp: undefined },
+        config.secret,
+      ),
+    ).toThrow(InvalidEnvironmentError);
+  });
+
+  it("rejects missing or invalid rate-limit configuration with Valibot", () => {
+    const restoreMissing = setRateLimitEnvironment({
+      SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: "5",
+      SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: "3600",
+    });
+    try {
+      expect(getSubmissionRateLimitConfig).toThrow(InvalidEnvironmentError);
+    } finally {
+      restoreMissing();
+    }
+
+    const restoreInvalid = setRateLimitEnvironment({
+      SUBMISSION_RATE_LIMIT_SECRET: config.secret,
+      SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: "not-a-number",
+      SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: "3600",
+    });
+    try {
+      expect(getSubmissionRateLimitConfig).toThrow(InvalidEnvironmentError);
+    } finally {
+      restoreInvalid();
+    }
+  });
+
+  it("uses one atomic Postgres upsert that admits no concurrent over-limit update", async () => {
+    const execute = vi.fn().mockResolvedValue({ rows: [{ attempt_count: 1 }] });
+    vi.mocked(getDb).mockReturnValue({ execute } as never);
+
+    await consumeSubmissionRateLimit("hmac-key", config);
+
+    const query = getPgQuery(execute.mock.calls[0]?.[0]);
+    expect(query.sql).toContain('INSERT INTO "public_submission_rate_limits"');
+    expect(query.sql).toContain(
+      'ON CONFLICT ("public_submission_rate_limits"."key_hash") DO UPDATE',
+    );
+    expect(query.sql).toContain(
+      '"public_submission_rate_limits"."attempt_count" < $',
+    );
+    expect(query.sql).toContain("make_interval(secs => $");
+    expect(query.sql).toContain(
+      'RETURNING "public_submission_rate_limits"."attempt_count"',
+    );
+    expect(query.sql).not.toContain("SELECT");
+    expect(query.params).toContain("hmac-key");
+    expect(query.params).toContain(config.maxAttempts);
+    expect(query.params).toContain(config.windowSeconds);
+  });
+
+  it("keeps the rate-limit state inaccessible to browser database roles", () => {
+    expect(rateLimitMigration).toContain(
+      'ALTER TABLE "public_submission_rate_limits" ENABLE ROW LEVEL SECURITY;',
+    );
+    expect(rateLimitMigration).toContain(
+      "REVOKE ALL PRIVILEGES ON TABLE public.public_submission_rate_limits\n  FROM anon, authenticated;",
+    );
+  });
+});

--- a/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
+++ b/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
@@ -19,9 +19,10 @@ import {
   type SubmissionRateLimitConfig,
 } from "../submission-rate-limit";
 import { getPgQuery } from "../../__tests__/test-utils";
+import { TEST_SUBMISSION_RATE_LIMIT_SECRET } from "../../../../src/test/rate-limit-fixtures";
 
 const config: SubmissionRateLimitConfig = {
-  secret: "test-submission-rate-limit-secret-1234567890",
+  secret: TEST_SUBMISSION_RATE_LIMIT_SECRET,
   maxAttempts: 5,
   windowSeconds: 3600,
 };
@@ -148,14 +149,27 @@ describe("submission rate limit", () => {
     } finally {
       restoreInvalid();
     }
+
+    for (const invalidSecret of ["a".repeat(63), "g".repeat(64)]) {
+      const restoreInvalidSecret = setRateLimitEnvironment({
+        SUBMISSION_RATE_LIMIT_SECRET: invalidSecret,
+        SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: "5",
+        SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: "3600",
+      });
+      try {
+        expect(getSubmissionRateLimitConfig).toThrow(InvalidEnvironmentError);
+      } finally {
+        restoreInvalidSecret();
+      }
+    }
   });
 
   it("declares the HMAC secret as sensitive external Varlock config", () => {
     expect(environmentSchema).toContain(
-      "# @type=string(minLength=32) @sensitive\nSUBMISSION_RATE_LIMIT_SECRET=",
+      "# @type=string(isLength=64,matches=/^[0-9A-Fa-f]{64}$/) @sensitive\nSUBMISSION_RATE_LIMIT_SECRET=",
     );
     expect(environmentSchema).not.toContain(
-      "# @type=string(minLength=32) @sensitive @required\nSUBMISSION_RATE_LIMIT_SECRET=",
+      "# @type=string(isLength=64,matches=/^[0-9A-Fa-f]{64}$/) @sensitive @required\nSUBMISSION_RATE_LIMIT_SECRET=",
     );
   });
 

--- a/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
+++ b/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 
-import { describe, expect, it, vi } from "vitest";
+import { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../db", () => ({
   getDb: vi.fn(),
@@ -13,6 +14,8 @@ import {
   consumeSubmissionRateLimit,
   createSubmissionRateLimitKey,
   getSubmissionRateLimitConfig,
+  SUBMISSION_RATE_LIMIT_CLEANUP_BATCH_SIZE,
+  SUBMISSION_RATE_LIMIT_RETENTION_SECONDS,
   type SubmissionRateLimitConfig,
 } from "../submission-rate-limit";
 import { getPgQuery } from "../../__tests__/test-utils";
@@ -30,6 +33,17 @@ const rateLimitMigration = readFileSync(
   ),
   "utf8",
 );
+const retentionIndexMigration = readFileSync(
+  new URL(
+    "../../../../migrations/postgres/0009_rich_supernaut.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const environmentSchema = readFileSync(
+  new URL("../../../../.env.schema", import.meta.url),
+  "utf8",
+);
 
 function setRateLimitEnvironment(
   values: Partial<Record<string, string>>,
@@ -41,12 +55,34 @@ function setRateLimitEnvironment(
   };
 }
 
+function createPgliteExecutor(database: PGlite) {
+  let pending = Promise.resolve();
+
+  return {
+    execute: (query: unknown) => {
+      const rendered = getPgQuery(query);
+      const operation = pending.then(async () => {
+        const result = await database.query(rendered.sql, rendered.params);
+        return { rows: result.rows };
+      });
+      pending = operation.then(
+        () => undefined,
+        () => undefined,
+      );
+      return operation;
+    },
+  };
+}
+
 describe("submission rate limit", () => {
   it("allows the first and boundary attempts, then rejects an over-limit attempt", async () => {
     const execute = vi
       .fn()
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ attempt_count: 1 }] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ attempt_count: 5 }] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] });
     vi.mocked(getDb).mockReturnValue({ execute } as never);
 
@@ -114,28 +150,50 @@ describe("submission rate limit", () => {
     }
   });
 
-  it("uses one atomic Postgres upsert that admits no concurrent over-limit update", async () => {
-    const execute = vi.fn().mockResolvedValue({ rows: [{ attempt_count: 1 }] });
+  it("declares the HMAC secret as required sensitive external Varlock config", () => {
+    expect(environmentSchema).toContain(
+      "# @type=string(minLength=32) @sensitive @required\nSUBMISSION_RATE_LIMIT_SECRET=",
+    );
+  });
+
+  it("keeps bounded cleanup separate from the atomic admission statement", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ attempt_count: 1 }] });
     vi.mocked(getDb).mockReturnValue({ execute } as never);
 
     await consumeSubmissionRateLimit("hmac-key", config);
 
-    const query = getPgQuery(execute.mock.calls[0]?.[0]);
-    expect(query.sql).toContain('INSERT INTO "public_submission_rate_limits"');
-    expect(query.sql).toContain(
-      'ON CONFLICT ("public_submission_rate_limits"."key_hash") DO UPDATE',
+    const cleanupQuery = getPgQuery(execute.mock.calls[0]?.[0]);
+    expect(cleanupQuery.sql).toContain("WITH stale_rows AS");
+    expect(cleanupQuery.sql).toContain("FOR UPDATE SKIP LOCKED");
+    expect(cleanupQuery.sql).toMatch(
+      /"public_submission_rate_limits"\."window_started_at"\s+<=/,
     );
-    expect(query.sql).toContain(
+    expect(cleanupQuery.params).toContain(
+      SUBMISSION_RATE_LIMIT_RETENTION_SECONDS,
+    );
+    expect(cleanupQuery.params).toContain(
+      SUBMISSION_RATE_LIMIT_CLEANUP_BATCH_SIZE,
+    );
+
+    const admissionQuery = getPgQuery(execute.mock.calls[1]?.[0]);
+    expect(admissionQuery.sql).toContain(
+      'INSERT INTO "public_submission_rate_limits"',
+    );
+    expect(admissionQuery.sql).toContain('ON CONFLICT ("key_hash") DO UPDATE');
+    expect(admissionQuery.sql).toContain(
       '"public_submission_rate_limits"."attempt_count" < $',
     );
-    expect(query.sql).toContain("make_interval(secs => $");
-    expect(query.sql).toContain(
+    expect(admissionQuery.sql).toContain("make_interval(secs => $");
+    expect(admissionQuery.sql).toContain(
       'RETURNING "public_submission_rate_limits"."attempt_count"',
     );
-    expect(query.sql).not.toContain("SELECT");
-    expect(query.params).toContain("hmac-key");
-    expect(query.params).toContain(config.maxAttempts);
-    expect(query.params).toContain(config.windowSeconds);
+    expect(admissionQuery.sql).not.toContain("SELECT");
+    expect(admissionQuery.params).toContain("hmac-key");
+    expect(admissionQuery.params).toContain(config.maxAttempts);
+    expect(admissionQuery.params).toContain(config.windowSeconds);
   });
 
   it("keeps the rate-limit state inaccessible to browser database roles", () => {
@@ -145,5 +203,100 @@ describe("submission rate limit", () => {
     expect(rateLimitMigration).toContain(
       "REVOKE ALL PRIVILEGES ON TABLE public.public_submission_rate_limits\n  FROM anon, authenticated;",
     );
+    expect(retentionIndexMigration).toContain(
+      'CREATE INDEX "idx_public_submission_rate_limits_updated_at" ON "public_submission_rate_limits" USING btree ("updated_at");',
+    );
+  });
+});
+
+describe.sequential("submission rate limit PostgreSQL execution", () => {
+  let database: PGlite;
+
+  beforeEach(async () => {
+    database = new PGlite();
+    await database.exec(`
+      CREATE TABLE public_submission_rate_limits (
+        key_hash text PRIMARY KEY NOT NULL,
+        window_started_at timestamp with time zone DEFAULT now() NOT NULL,
+        attempt_count integer DEFAULT 1 NOT NULL,
+        updated_at timestamp with time zone DEFAULT now() NOT NULL,
+        CONSTRAINT public_submission_rate_limits_attempt_count_check
+          CHECK (attempt_count > 0)
+      );
+      CREATE INDEX idx_public_submission_rate_limits_updated_at
+        ON public_submission_rate_limits (updated_at);
+    `);
+    vi.mocked(getDb).mockReturnValue(createPgliteExecutor(database) as never);
+  });
+
+  afterEach(async () => {
+    await database.close();
+  });
+
+  it("admits exactly max requests in a serialized burst and resets an expired window to one", async () => {
+    const attemptCount = config.maxAttempts + 7;
+    const admissions = await Promise.all(
+      Array.from({ length: attemptCount }, () =>
+        consumeSubmissionRateLimit("concurrent-key", config),
+      ),
+    );
+
+    expect(admissions.filter(Boolean)).toHaveLength(config.maxAttempts);
+    await expect(
+      database.query<{ attempt_count: number }>(
+        "SELECT attempt_count FROM public_submission_rate_limits WHERE key_hash = $1",
+        ["concurrent-key"],
+      ),
+    ).resolves.toMatchObject({ rows: [{ attempt_count: config.maxAttempts }] });
+
+    await database.query(
+      `UPDATE public_submission_rate_limits
+       SET window_started_at = now() - interval '2 hours', updated_at = now()
+       WHERE key_hash = $1`,
+      ["concurrent-key"],
+    );
+
+    await expect(
+      consumeSubmissionRateLimit("concurrent-key", config),
+    ).resolves.toBe(true);
+    await expect(
+      database.query<{ attempt_count: number }>(
+        "SELECT attempt_count FROM public_submission_rate_limits WHERE key_hash = $1",
+        ["concurrent-key"],
+      ),
+    ).resolves.toMatchObject({ rows: [{ attempt_count: 1 }] });
+  });
+
+  it("deletes at most one batch of retained expired rows and preserves active windows", async () => {
+    const staleCount = SUBMISSION_RATE_LIMIT_CLEANUP_BATCH_SIZE + 5;
+    await database.query(
+      `INSERT INTO public_submission_rate_limits
+         (key_hash, window_started_at, attempt_count, updated_at)
+       SELECT
+         'stale-' || value,
+         now() - interval '31 days',
+         1,
+         now() - interval '31 days'
+       FROM generate_series(1, $1) AS value`,
+      [staleCount],
+    );
+    await database.query(
+      `INSERT INTO public_submission_rate_limits
+         (key_hash, window_started_at, attempt_count, updated_at)
+       VALUES ('active-key', now(), 1, now() - interval '31 days')`,
+    );
+
+    await consumeSubmissionRateLimit("cleanup-trigger", config);
+
+    await expect(
+      database.query<{ count: number }>(
+        "SELECT count(*)::int AS count FROM public_submission_rate_limits WHERE key_hash LIKE 'stale-%'",
+      ),
+    ).resolves.toMatchObject({ rows: [{ count: 5 }] });
+    await expect(
+      database.query<{ key_hash: string }>(
+        "SELECT key_hash FROM public_submission_rate_limits WHERE key_hash = 'active-key'",
+      ),
+    ).resolves.toMatchObject({ rows: [{ key_hash: "active-key" }] });
   });
 });

--- a/netlify/functions/lib/db.ts
+++ b/netlify/functions/lib/db.ts
@@ -2,14 +2,7 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 
 import * as schema from "../../../src/db/schema";
-
-function getEnv(key: string): string | undefined {
-  if (typeof Netlify !== "undefined" && Netlify?.env) {
-    return Netlify.env.get(key) ?? undefined;
-  }
-
-  return process.env[key];
-}
+import { getEnv } from "./env";
 
 function createDbClient() {
   const connectionString = getEnv("SUPABASE_DATABASE_URL") ?? getEnv("DATABASE_URL");

--- a/netlify/functions/lib/env.ts
+++ b/netlify/functions/lib/env.ts
@@ -22,13 +22,32 @@ export class MissingEnvironmentError extends Error {
   }
 }
 
+/** Error type used when environment values fail their feature-specific contract. */
+export class InvalidEnvironmentError extends Error {
+  readonly invalidKeys: string[];
+
+  constructor(invalidKeys: string[]) {
+    super("Environment variables are invalid");
+    this.name = "InvalidEnvironmentError";
+    this.invalidKeys = invalidKeys;
+  }
+}
+
+/** Reads a server environment value from Netlify or the local process. */
+export function getEnv(key: string): string | undefined {
+  if (typeof Netlify !== "undefined" && Netlify?.env) {
+    return Netlify.env.get(key) ?? undefined;
+  }
+
+  return process.env[key];
+}
+
 /**
  * Throws when one or more required environment variables are missing.
  */
 export function assertRequiredEnv(requiredKeys: readonly string[]): void {
   const missingKeys = requiredKeys.filter((key) => {
-    const value =
-      typeof Netlify !== "undefined" && Netlify?.env ? Netlify.env.get(key) : process.env[key];
+    const value = getEnv(key);
 
     return !value || value.trim() === "";
   });
@@ -43,6 +62,11 @@ export function assertRequiredEnv(requiredKeys: readonly string[]): void {
  */
 export function isMissingEnvironmentError(error: unknown): error is MissingEnvironmentError {
   return error instanceof MissingEnvironmentError;
+}
+
+/** Type guard for invalid environment errors. */
+export function isInvalidEnvironmentError(error: unknown): error is InvalidEnvironmentError {
+  return error instanceof InvalidEnvironmentError;
 }
 
 /**
@@ -66,6 +90,23 @@ export async function handleMissingEnvironmentError(
   captureError(error, {
     function: functionName,
     missingKeys: error.missingKeys,
+  });
+  await flushSentry();
+  return serviceUnavailable(getServiceUnavailableMessage());
+}
+
+/** Maps invalid environment values to the same safe client response as missing values. */
+export async function handleInvalidEnvironmentError(
+  error: unknown,
+  functionName: string,
+): Promise<Response> {
+  if (!isInvalidEnvironmentError(error)) {
+    throw error;
+  }
+
+  captureError(error, {
+    function: functionName,
+    invalidKeys: error.invalidKeys,
   });
   await flushSentry();
   return serviceUnavailable(getServiceUnavailableMessage());

--- a/netlify/functions/lib/env.ts
+++ b/netlify/functions/lib/env.ts
@@ -33,13 +33,9 @@ export class InvalidEnvironmentError extends Error {
   }
 }
 
-/** Reads a server environment value from Netlify or the local process. */
+/** Reads a server environment value from the Netlify runtime. */
 export function getEnv(key: string): string | undefined {
-  if (typeof Netlify !== "undefined" && Netlify?.env) {
-    return Netlify.env.get(key) ?? undefined;
-  }
-
-  return process.env[key];
+  return Netlify.env.get(key) ?? undefined;
 }
 
 /**

--- a/netlify/functions/lib/index.ts
+++ b/netlify/functions/lib/index.ts
@@ -15,11 +15,17 @@ export {
 } from "./auth";
 export { assertRequiredEnv, handleMissingEnvironmentError } from "./env";
 export {
+  consumeSubmissionRateLimit,
+  createSubmissionRateLimitKey,
+  getSubmissionRateLimitConfig,
+} from "./submission-rate-limit";
+export {
   bookmarksTable,
   resourcesTable,
   toolListingsTable,
   publicListingsTable,
   publicStacksTable,
   publicStackItemsTable,
+  publicSubmissionRateLimitsTable,
   userRolesTable,
 } from "../../../src/db/schema";

--- a/netlify/functions/lib/responses.ts
+++ b/netlify/functions/lib/responses.ts
@@ -108,6 +108,11 @@ export function serviceUnavailable(error: string): Response {
   return jsonResponse({ success: false, error }, 503);
 }
 
+/** Generic dependency failure response with no internal implementation details. */
+export function dependencyUnavailable(): Response {
+  return serviceUnavailable("Service temporarily unavailable");
+}
+
 /**
  * Method not allowed (405)
  */

--- a/netlify/functions/lib/responses.ts
+++ b/netlify/functions/lib/responses.ts
@@ -76,6 +76,17 @@ export function conflict(error: string): Response {
   return jsonResponse({ success: false, error }, 409);
 }
 
+/** Generic rate-limit response; it intentionally reveals no enforcement details. */
+export function tooManyRequests(): Response {
+  return jsonResponse(
+    {
+      success: false,
+      error: "Too many submission attempts. Please try again later.",
+    },
+    429,
+  );
+}
+
 /**
  * Not found error (404)
  */

--- a/netlify/functions/lib/responses.ts
+++ b/netlify/functions/lib/responses.ts
@@ -23,6 +23,7 @@ function jsonResponse<T>(body: ApiResponse<T>, status: number): Response {
     status,
     headers: {
       "Content-Type": "application/json",
+      "X-Content-Type-Options": "nosniff",
     },
   });
 }
@@ -126,6 +127,7 @@ export function methodNotAllowed(allowed: string[]): Response {
       status: 405,
       headers: {
         "Content-Type": "application/json",
+        "X-Content-Type-Options": "nosniff",
         Allow: allowed.join(", "),
       },
     },

--- a/netlify/functions/lib/submission-rate-limit.ts
+++ b/netlify/functions/lib/submission-rate-limit.ts
@@ -14,6 +14,14 @@ const SUBMISSION_RATE_LIMIT_ENV_KEYS = [
   "SUBMISSION_RATE_LIMIT_WINDOW_SECONDS",
 ] as const;
 
+export const SUBMISSION_RATE_LIMIT_RETENTION_SECONDS = 30 * 24 * 60 * 60;
+export const SUBMISSION_RATE_LIMIT_CLEANUP_BATCH_SIZE = 100;
+
+const keyHashColumn = sql.identifier("key_hash");
+const windowStartedAtColumn = sql.identifier("window_started_at");
+const attemptCountColumn = sql.identifier("attempt_count");
+const updatedAtColumn = sql.identifier("updated_at");
+
 const positiveIntegerStringSchema = v.pipe(
   v.string(),
   v.regex(/^[1-9][0-9]*$/, "Must be a positive integer"),
@@ -93,34 +101,59 @@ export function createSubmissionRateLimitKey(
   return createHmac("sha256", secret).update(subject).digest("hex");
 }
 
+/** Removes a bounded batch of expired rows older than the retention period. */
+async function cleanupStaleSubmissionRateLimits(
+  config: SubmissionRateLimitConfig,
+): Promise<void> {
+  await getDb().execute(sql`
+    WITH stale_rows AS (
+      SELECT ${publicSubmissionRateLimitsTable.keyHash}
+      FROM ${publicSubmissionRateLimitsTable}
+      WHERE
+        ${publicSubmissionRateLimitsTable.updatedAt}
+          < now() - make_interval(secs => ${SUBMISSION_RATE_LIMIT_RETENTION_SECONDS})
+        AND ${publicSubmissionRateLimitsTable.windowStartedAt}
+          <= now() - make_interval(secs => ${config.windowSeconds})
+      ORDER BY ${publicSubmissionRateLimitsTable.updatedAt}
+      LIMIT ${SUBMISSION_RATE_LIMIT_CLEANUP_BATCH_SIZE}
+      FOR UPDATE SKIP LOCKED
+    )
+    DELETE FROM ${publicSubmissionRateLimitsTable}
+    USING stale_rows
+    WHERE ${publicSubmissionRateLimitsTable.keyHash} = stale_rows.key_hash
+  `);
+}
+
 /** Atomically consumes one rate-limit slot and returns whether the request may proceed. */
 export async function consumeSubmissionRateLimit(
   keyHash: string,
   config: SubmissionRateLimitConfig,
 ): Promise<boolean> {
+  await cleanupStaleSubmissionRateLimits(config);
+
   const result = await getDb().execute(sql`
     INSERT INTO ${publicSubmissionRateLimitsTable} (
-      ${publicSubmissionRateLimitsTable.keyHash},
-      ${publicSubmissionRateLimitsTable.windowStartedAt},
-      ${publicSubmissionRateLimitsTable.attemptCount},
-      ${publicSubmissionRateLimitsTable.updatedAt}
+      ${keyHashColumn},
+      ${windowStartedAtColumn},
+      ${attemptCountColumn},
+      ${updatedAtColumn}
     )
     VALUES (${keyHash}, now(), 1, now())
-    ON CONFLICT (${publicSubmissionRateLimitsTable.keyHash}) DO UPDATE
+    ON CONFLICT (${keyHashColumn}) DO UPDATE
     SET
-      ${publicSubmissionRateLimitsTable.windowStartedAt} = CASE
+      ${windowStartedAtColumn} = CASE
         WHEN ${publicSubmissionRateLimitsTable.windowStartedAt}
           <= now() - make_interval(secs => ${config.windowSeconds})
         THEN now()
         ELSE ${publicSubmissionRateLimitsTable.windowStartedAt}
       END,
-      ${publicSubmissionRateLimitsTable.attemptCount} = CASE
+      ${attemptCountColumn} = CASE
         WHEN ${publicSubmissionRateLimitsTable.windowStartedAt}
           <= now() - make_interval(secs => ${config.windowSeconds})
         THEN 1
         ELSE ${publicSubmissionRateLimitsTable.attemptCount} + 1
       END,
-      ${publicSubmissionRateLimitsTable.updatedAt} = now()
+      ${updatedAtColumn} = now()
     WHERE
       ${publicSubmissionRateLimitsTable.windowStartedAt}
         <= now() - make_interval(secs => ${config.windowSeconds})

--- a/netlify/functions/lib/submission-rate-limit.ts
+++ b/netlify/functions/lib/submission-rate-limit.ts
@@ -1,0 +1,132 @@
+import { createHmac } from "node:crypto";
+
+import { sql } from "drizzle-orm";
+import * as v from "valibot";
+
+import { publicSubmissionRateLimitsTable } from "../../../src/db/schema";
+import type { AuthenticatedUser } from "./auth";
+import { getDb } from "./db";
+import { getEnv, InvalidEnvironmentError } from "./env";
+
+const SUBMISSION_RATE_LIMIT_ENV_KEYS = [
+  "SUBMISSION_RATE_LIMIT_SECRET",
+  "SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS",
+  "SUBMISSION_RATE_LIMIT_WINDOW_SECONDS",
+] as const;
+
+const positiveIntegerStringSchema = v.pipe(
+  v.string(),
+  v.regex(/^[1-9][0-9]*$/, "Must be a positive integer"),
+  v.transform(Number),
+  v.integer(),
+  v.minValue(1),
+);
+
+/** Validates the server-only controls that tune public submission throttling. */
+export const submissionRateLimitEnvironmentSchema = v.object({
+  SUBMISSION_RATE_LIMIT_SECRET: v.pipe(
+    v.string(),
+    v.minLength(32, "Must contain at least 32 characters"),
+  ),
+  SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: v.pipe(
+    positiveIntegerStringSchema,
+    v.maxValue(1000),
+  ),
+  SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: v.pipe(
+    positiveIntegerStringSchema,
+    v.maxValue(86_400),
+  ),
+});
+
+export interface SubmissionRateLimitConfig {
+  secret: string;
+  maxAttempts: number;
+  windowSeconds: number;
+}
+
+interface SubmissionRateLimitIdentity {
+  authenticated: AuthenticatedUser | null;
+  clientIp: string | undefined;
+}
+
+/** Reads and validates the server-only rate-limit configuration. */
+export function getSubmissionRateLimitConfig(): SubmissionRateLimitConfig {
+  const environment = Object.fromEntries(
+    SUBMISSION_RATE_LIMIT_ENV_KEYS.map((key) => [key, getEnv(key)]),
+  );
+  const validation = v.safeParse(
+    submissionRateLimitEnvironmentSchema,
+    environment,
+  );
+
+  if (!validation.success) {
+    const invalidKeys = [
+      ...new Set(
+        validation.issues
+          .map((issue) => issue.path?.[0]?.key)
+          .filter((key): key is string => typeof key === "string"),
+      ),
+    ];
+    throw new InvalidEnvironmentError(invalidKeys);
+  }
+
+  return {
+    secret: validation.output.SUBMISSION_RATE_LIMIT_SECRET,
+    maxAttempts: validation.output.SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS,
+    windowSeconds: validation.output.SUBMISSION_RATE_LIMIT_WINDOW_SECONDS,
+  };
+}
+
+/** Creates the non-reversible, server-only rate-limit key for a submitter. */
+export function createSubmissionRateLimitKey(
+  identity: SubmissionRateLimitIdentity,
+  secret: string,
+): string {
+  const subject = identity.authenticated
+    ? `user:${identity.authenticated.user.id}`
+    : `ip:${identity.clientIp?.trim() ?? ""}`;
+
+  if (!identity.authenticated && !identity.clientIp?.trim()) {
+    throw new InvalidEnvironmentError(["NETLIFY_CONTEXT_IP"]);
+  }
+
+  return createHmac("sha256", secret).update(subject).digest("hex");
+}
+
+/** Atomically consumes one rate-limit slot and returns whether the request may proceed. */
+export async function consumeSubmissionRateLimit(
+  keyHash: string,
+  config: SubmissionRateLimitConfig,
+): Promise<boolean> {
+  const result = await getDb().execute(sql`
+    INSERT INTO ${publicSubmissionRateLimitsTable} (
+      ${publicSubmissionRateLimitsTable.keyHash},
+      ${publicSubmissionRateLimitsTable.windowStartedAt},
+      ${publicSubmissionRateLimitsTable.attemptCount},
+      ${publicSubmissionRateLimitsTable.updatedAt}
+    )
+    VALUES (${keyHash}, now(), 1, now())
+    ON CONFLICT (${publicSubmissionRateLimitsTable.keyHash}) DO UPDATE
+    SET
+      ${publicSubmissionRateLimitsTable.windowStartedAt} = CASE
+        WHEN ${publicSubmissionRateLimitsTable.windowStartedAt}
+          <= now() - make_interval(secs => ${config.windowSeconds})
+        THEN now()
+        ELSE ${publicSubmissionRateLimitsTable.windowStartedAt}
+      END,
+      ${publicSubmissionRateLimitsTable.attemptCount} = CASE
+        WHEN ${publicSubmissionRateLimitsTable.windowStartedAt}
+          <= now() - make_interval(secs => ${config.windowSeconds})
+        THEN 1
+        ELSE ${publicSubmissionRateLimitsTable.attemptCount} + 1
+      END,
+      ${publicSubmissionRateLimitsTable.updatedAt} = now()
+    WHERE
+      ${publicSubmissionRateLimitsTable.windowStartedAt}
+        <= now() - make_interval(secs => ${config.windowSeconds})
+      OR ${publicSubmissionRateLimitsTable.attemptCount} < ${config.maxAttempts}
+    RETURNING ${publicSubmissionRateLimitsTable.attemptCount}
+  `);
+
+  return result.rows.length > 0;
+}

--- a/netlify/functions/lib/submission-rate-limit.ts
+++ b/netlify/functions/lib/submission-rate-limit.ts
@@ -34,7 +34,10 @@ const positiveIntegerStringSchema = v.pipe(
 export const submissionRateLimitEnvironmentSchema = v.object({
   SUBMISSION_RATE_LIMIT_SECRET: v.pipe(
     v.string(),
-    v.minLength(32, "Must contain at least 32 characters"),
+    v.regex(
+      /^[0-9A-Fa-f]{64}$/,
+      "Must contain exactly 64 hexadecimal characters",
+    ),
   ),
   SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: v.pipe(
     positiveIntegerStringSchema,

--- a/netlify/functions/lib/submissions.ts
+++ b/netlify/functions/lib/submissions.ts
@@ -1,3 +1,4 @@
+import type { Context } from "@netlify/functions";
 import type { BaseIssue } from "valibot";
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
@@ -9,16 +10,26 @@ import {
   verifyAuthenticatedUser,
 } from "./auth";
 import { getDb } from "./db";
-import { assertRequiredEnv, handleMissingEnvironmentError } from "./env";
+import {
+  assertRequiredEnv,
+  handleInvalidEnvironmentError,
+  handleMissingEnvironmentError,
+} from "./env";
 import {
   conflict,
   created,
   methodNotAllowed,
   serverError,
+  tooManyRequests,
   unauthorized,
   validationError,
 } from "./responses";
 import { captureError, flushSentry, initSentry } from "./sentry";
+import {
+  consumeSubmissionRateLimit,
+  createSubmissionRateLimitKey,
+  getSubmissionRateLimitConfig,
+} from "./submission-rate-limit";
 import { normalizeUrl, parseAndNormalizeUrl } from "./url";
 import {
   publicListingsTable,
@@ -64,6 +75,7 @@ const BLOCKED_IPV4_RANGES: readonly [
 type PublicListingSubmissionType = Exclude<PublicSubmissionType, "tool">;
 
 interface PublicSubmissionOptions {
+  context: Context;
   endpointName: string;
   allowedTypes?: readonly PublicSubmissionType[];
   rejectedTypeDetails?: Record<string, string[]>;
@@ -491,6 +503,24 @@ export async function handlePublicSubmission(
     !options.allowedTypes.includes(validation.output.type)
   ) {
     return validationError("Validation failed", options.rejectedTypeDetails);
+  }
+
+  try {
+    const rateLimitConfig = getSubmissionRateLimitConfig();
+    const keyHash = createSubmissionRateLimitKey(
+      {
+        authenticated,
+        clientIp: options.context.ip,
+      },
+      rateLimitConfig.secret,
+    );
+    const allowed = await consumeSubmissionRateLimit(keyHash, rateLimitConfig);
+
+    if (!allowed) {
+      return tooManyRequests();
+    }
+  } catch (error) {
+    return handleInvalidEnvironmentError(error, options.endpointName);
   }
 
   const normalizedUrl = parseAndNormalizeUrl(validation.output.url);

--- a/netlify/functions/lib/submissions.ts
+++ b/netlify/functions/lib/submissions.ts
@@ -18,6 +18,7 @@ import {
 import {
   conflict,
   created,
+  dependencyUnavailable,
   methodNotAllowed,
   serverError,
   tooManyRequests,
@@ -29,6 +30,7 @@ import {
   consumeSubmissionRateLimit,
   createSubmissionRateLimitKey,
   getSubmissionRateLimitConfig,
+  type SubmissionRateLimitConfig,
 } from "./submission-rate-limit";
 import { normalizeUrl, parseAndNormalizeUrl } from "./url";
 import {
@@ -505,22 +507,37 @@ export async function handlePublicSubmission(
     return validationError("Validation failed", options.rejectedTypeDetails);
   }
 
+  let rateLimitConfig: SubmissionRateLimitConfig;
+  let keyHash: string;
   try {
-    const rateLimitConfig = getSubmissionRateLimitConfig();
-    const keyHash = createSubmissionRateLimitKey(
+    rateLimitConfig = getSubmissionRateLimitConfig();
+    keyHash = createSubmissionRateLimitKey(
       {
         authenticated,
         clientIp: options.context.ip,
       },
       rateLimitConfig.secret,
     );
+  } catch (error) {
+    return handleInvalidEnvironmentError(error, options.endpointName);
+  }
+
+  try {
     const allowed = await consumeSubmissionRateLimit(keyHash, rateLimitConfig);
 
     if (!allowed) {
       return tooManyRequests();
     }
-  } catch (error) {
-    return handleInvalidEnvironmentError(error, options.endpointName);
+  } catch {
+    captureError(
+      new Error("Submission rate limit datastore operation failed"),
+      {
+        function: options.endpointName,
+        dependency: "submission-rate-limit-store",
+      },
+    );
+    await flushSentry();
+    return dependencyUnavailable();
   }
 
   const normalizedUrl = parseAndNormalizeUrl(validation.output.url);

--- a/netlify/functions/process-tool.mts
+++ b/netlify/functions/process-tool.mts
@@ -2,8 +2,9 @@ import type { Config, Context } from "@netlify/functions";
 
 import { handlePublicSubmission } from "./lib/submissions";
 
-export default async (req: Request, _context: Context) => {
+export default async (req: Request, context: Context) => {
   return await handlePublicSubmission(req, {
+    context,
     endpointName: "process-tool",
     allowedTypes: ["tool"],
     rejectedTypeDetails: {

--- a/netlify/functions/public-submissions.mts
+++ b/netlify/functions/public-submissions.mts
@@ -2,8 +2,9 @@ import type { Config, Context } from "@netlify/functions";
 
 import { handlePublicSubmission } from "./lib/submissions";
 
-export default async (req: Request, _context: Context) => {
+export default async (req: Request, context: Context) => {
   return await handlePublicSubmission(req, {
+    context,
     endpointName: "public-submissions",
   });
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.2.1",
+    "@electric-sql/pglite": "^0.5.4",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.60.0",
     "@rolldown/plugin-babel": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 2.10.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -54,6 +54,9 @@ importers:
       '@chromatic-com/storybook':
         specifier: ^5.2.1
         version: 5.2.1(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react@19.2.7))
+      '@electric-sql/pglite':
+        specifier: ^0.5.4
+        version: 0.5.4
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.0)
@@ -355,6 +358,9 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@electric-sql/pglite@0.5.4':
+    resolution: {integrity: sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -4194,6 +4200,8 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@electric-sql/pglite@0.5.4': {}
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -5923,8 +5931,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0):
     optionalDependencies:
+      '@electric-sql/pglite': 0.5.4
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
       pg: 8.22.0

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,6 +4,7 @@ import {
   bigint,
   check,
   index,
+  integer,
   pgSchema,
   pgTable,
   text,
@@ -283,6 +284,28 @@ export const userPreferencesTable = pgTable("user_preferences", {
     .notNull(),
   ...timestamps,
 }).enableRLS();
+
+// Server-only abuse-control state. The database migration explicitly revokes
+// browser roles so this keyed, pseudonymous data cannot be queried via Supabase.
+export const publicSubmissionRateLimitsTable = pgTable(
+  "public_submission_rate_limits",
+  {
+    keyHash: text("key_hash").primaryKey(),
+    windowStartedAt: timestamp("window_started_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    attemptCount: integer("attempt_count").default(1).notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    check(
+      "public_submission_rate_limits_attempt_count_check",
+      sql`${table.attemptCount} > 0`,
+    ),
+  ],
+).enableRLS();
 
 export type InsertResource = typeof resourcesTable.$inferInsert;
 export type SelectResource = typeof resourcesTable.$inferSelect;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -300,6 +300,7 @@ export const publicSubmissionRateLimitsTable = pgTable(
       .notNull(),
   },
   (table) => [
+    index("idx_public_submission_rate_limits_updated_at").on(table.updatedAt),
     check(
       "public_submission_rate_limits_attempt_count_check",
       sql`${table.attemptCount} > 0`,

--- a/src/test/rate-limit-fixtures.ts
+++ b/src/test/rate-limit-fixtures.ts
@@ -1,0 +1,5 @@
+const secretBytes = crypto.getRandomValues(new Uint8Array(32));
+
+export const TEST_SUBMISSION_RATE_LIMIT_SECRET = Array.from(secretBytes, (byte) =>
+  byte.toString(16).padStart(2, "0"),
+).join("");

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -33,6 +33,10 @@ vi.stubGlobal("Netlify", {
         CLOUDINARY_CLOUD_NAME: "test-cloud",
         CLOUDINARY_API_KEY: "test-api-key",
         CLOUDINARY_API_SECRET: "test-api-secret",
+        SUBMISSION_RATE_LIMIT_SECRET:
+          "test-submission-rate-limit-secret-1234567890",
+        SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: "5",
+        SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: "3600",
       };
       return testEnv[key];
     },
@@ -45,6 +49,9 @@ vi.stubGlobal("Netlify", {
         "CLOUDINARY_CLOUD_NAME",
         "CLOUDINARY_API_KEY",
         "CLOUDINARY_API_SECRET",
+        "SUBMISSION_RATE_LIMIT_SECRET",
+        "SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS",
+        "SUBMISSION_RATE_LIMIT_WINDOW_SECONDS",
       ];
       return keys.includes(key);
     },

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,6 @@
 import { beforeAll, afterAll, afterEach, vi } from "vitest";
 import { server } from "./mocks/server";
+import { TEST_SUBMISSION_RATE_LIMIT_SECRET } from "./rate-limit-fixtures";
 import "@testing-library/jest-dom/vitest";
 
 /**
@@ -33,8 +34,7 @@ vi.stubGlobal("Netlify", {
         CLOUDINARY_CLOUD_NAME: "test-cloud",
         CLOUDINARY_API_KEY: "test-api-key",
         CLOUDINARY_API_SECRET: "test-api-secret",
-        SUBMISSION_RATE_LIMIT_SECRET:
-          "test-submission-rate-limit-secret-1234567890",
+        SUBMISSION_RATE_LIMIT_SECRET: TEST_SUBMISSION_RATE_LIMIT_SECRET,
         SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: "5",
         SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: "3600",
       };


### PR DESCRIPTION
## Summary
- add a durable PostgreSQL fixed-window limiter for public tool and resource submissions
- key verified users and anonymous Netlify client IPs with HMAC-SHA-256
- fail closed before metadata, screenshots, or moderation inserts, with generic 429/503 responses
- add bounded 30-day retention cleanup, RLS-protected schema migrations, deployment docs, and PostgreSQL execution tests

## Verification
- 44 focused unit/PostgreSQL execution tests pass
- `pnpm run typecheck`
- `pnpm run lint` (one pre-existing generated `public/mockServiceWorker.js` warning)
- `git diff --check`

Closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side rate limiting for public submissions.
  * Requests exceeding configured limits now receive a clear rate-limit response.
  * Submission processing fails safely when rate-limit services or configuration are unavailable.

* **Documentation**
  * Added setup and deployment guidance for rate-limiting configuration.
  * Documented anonymous and authenticated submission handling.

* **Bug Fixes**
  * Spoofed client IP headers are no longer used for anonymous rate-limit tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->