### PR TITLE
Add URL blocklist enforcement for public submissions

### DIFF
--- a/migrations/postgres/0010_lame_rage.sql
+++ b/migrations/postgres/0010_lame_rage.sql
@@ -16,7 +16,8 @@ CREATE TABLE "public_submission_blocklist" (
 	"normalized_value" text NOT NULL,
 	"created_by" uuid,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "public_submission_blocklist_value_check" CHECK (length(btrim("public_submission_blocklist"."normalized_value")) > 0)
+	CONSTRAINT "public_submission_blocklist_value_check" CHECK (length(btrim("public_submission_blocklist"."normalized_value")) > 0),
+	CONSTRAINT "public_submission_blocklist_match_type_check" CHECK ("public_submission_blocklist"."match_type" in ('url', 'domain'))
 );
 --> statement-breakpoint
 ALTER TABLE "public_submission_blocklist" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint

--- a/migrations/postgres/0010_lame_rage.sql
+++ b/migrations/postgres/0010_lame_rage.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "public_submission_blocklist_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"blocklist_entry_id" uuid,
+	"normalized_url" text NOT NULL,
+	"matched_type" text NOT NULL,
+	"matched_value" text NOT NULL,
+	"submitted_by_user_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "public_submission_blocklist_events" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "public_submission_blocklist" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"match_type" text NOT NULL,
+	"value" text NOT NULL,
+	"normalized_value" text NOT NULL,
+	"created_by" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "public_submission_blocklist_value_check" CHECK (length(btrim("public_submission_blocklist"."normalized_value")) > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "public_submission_blocklist" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "public_submission_blocklist_events" ADD CONSTRAINT "public_submission_blocklist_events_blocklist_entry_id_public_submission_blocklist_id_fk" FOREIGN KEY ("blocklist_entry_id") REFERENCES "public"."public_submission_blocklist"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "public_submission_blocklist_events" ADD CONSTRAINT "public_submission_blocklist_events_submitted_by_user_id_users_id_fk" FOREIGN KEY ("submitted_by_user_id") REFERENCES "auth"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "public_submission_blocklist" ADD CONSTRAINT "public_submission_blocklist_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "auth"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_public_submission_blocklist_events_created_at" ON "public_submission_blocklist_events" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "idx_public_submission_blocklist_events_entry" ON "public_submission_blocklist_events" USING btree ("blocklist_entry_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_public_submission_blocklist_match" ON "public_submission_blocklist" USING btree ("match_type","normalized_value");--> statement-breakpoint
+CREATE INDEX "idx_public_submission_blocklist_created_at" ON "public_submission_blocklist" USING btree ("created_at");--> statement-breakpoint
+REVOKE ALL ON TABLE "public_submission_blocklist" FROM anon, authenticated;--> statement-breakpoint
+REVOKE ALL ON TABLE "public_submission_blocklist_events" FROM anon, authenticated;

--- a/migrations/postgres/meta/0010_snapshot.json
+++ b/migrations/postgres/meta/0010_snapshot.json
@@ -1,0 +1,1684 @@
+{
+  "id": "25ed0f9d-59f7-4b15-b69d-4a332d0a8028",
+  "prevId": "500f714f-2e99-4885-b0c4-bc6f14084ed7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_override": {
+          "name": "title_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_override": {
+          "name": "description_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookmarks_user_created": {
+          "name": "idx_bookmarks_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_parent": {
+          "name": "idx_bookmarks_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookmarks_resource": {
+          "name": "idx_bookmarks_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_user_resource": {
+          "name": "unique_user_resource",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_resource_id_resources_id_fk": {
+          "name": "bookmarks_resource_id_resources_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_parent_id_bookmarks_id_fk": {
+          "name": "bookmarks_parent_id_bookmarks_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_listings": {
+      "name": "public_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_by_bookmark_id": {
+          "name": "submitted_by_bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_github_url": {
+          "name": "submitter_github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resource'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_public_listings_status": {
+          "name": "idx_public_listings_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_listings_tags": {
+          "name": "idx_public_listings_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_listings_search": {
+          "name": "idx_public_listings_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_listings_resource": {
+          "name": "idx_public_listings_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_public_listing_resource": {
+          "name": "unique_public_listing_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_listings_resource_id_resources_id_fk": {
+          "name": "public_listings_resource_id_resources_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_listings_submitted_by_user_id_users_id_fk": {
+          "name": "public_listings_submitted_by_user_id_users_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_listings_submitted_by_bookmark_id_bookmarks_id_fk": {
+          "name": "public_listings_submitted_by_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["submitted_by_bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "public_listings_reviewed_by_users_id_fk": {
+          "name": "public_listings_reviewed_by_users_id_fk",
+          "tableFrom": "public_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "public_listings_content_kind_check": {
+          "name": "public_listings_content_kind_check",
+          "value": "\"public_listings\".\"content_kind\" in ('article', 'resource')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.public_stack_items": {
+      "name": "public_stack_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public_stack_id": {
+          "name": "public_stack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookmark_id": {
+          "name": "bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_public_listing_id": {
+          "name": "source_public_listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_public_stack_item_bookmark": {
+          "name": "unique_public_stack_item_bookmark",
+          "columns": [
+            {
+              "expression": "bookmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_public_stack_resource": {
+          "name": "unique_public_stack_resource",
+          "columns": [
+            {
+              "expression": "public_stack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_status": {
+          "name": "idx_public_stack_items_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_stack": {
+          "name": "idx_public_stack_items_stack",
+          "columns": [
+            {
+              "expression": "public_stack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stack_items_tags": {
+          "name": "idx_public_stack_items_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stack_items_search": {
+          "name": "idx_public_stack_items_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stack_items_resource": {
+          "name": "idx_public_stack_items_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_stack_items_public_stack_id_public_stacks_id_fk": {
+          "name": "public_stack_items_public_stack_id_public_stacks_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "public_stacks",
+          "columnsFrom": ["public_stack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_bookmark_id_bookmarks_id_fk": {
+          "name": "public_stack_items_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_resource_id_resources_id_fk": {
+          "name": "public_stack_items_resource_id_resources_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_source_public_listing_id_public_listings_id_fk": {
+          "name": "public_stack_items_source_public_listing_id_public_listings_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "public_listings",
+          "columnsFrom": ["source_public_listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "public_stack_items_reviewed_by_users_id_fk": {
+          "name": "public_stack_items_reviewed_by_users_id_fk",
+          "tableFrom": "public_stack_items",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_stacks": {
+      "name": "public_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root_bookmark_id": {
+          "name": "root_bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_public_stack_root": {
+          "name": "unique_public_stack_root",
+          "columns": [
+            {
+              "expression": "root_bookmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_status": {
+          "name": "idx_public_stacks_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_tags": {
+          "name": "idx_public_stacks_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stacks_search": {
+          "name": "idx_public_stacks_search",
+          "columns": [
+            {
+              "expression": "(\n        page_title || ' ' || meta_description || ' ' || public.immutable_array_to_string(tags, ' ')\n      ) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_public_stacks_owner": {
+          "name": "idx_public_stacks_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_stacks_resource": {
+          "name": "idx_public_stacks_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_stacks_root_bookmark_id_bookmarks_id_fk": {
+          "name": "public_stacks_root_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["root_bookmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_resource_id_resources_id_fk": {
+          "name": "public_stacks_resource_id_resources_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_owner_user_id_users_id_fk": {
+          "name": "public_stacks_owner_user_id_users_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_stacks_reviewed_by_users_id_fk": {
+          "name": "public_stacks_reviewed_by_users_id_fk",
+          "tableFrom": "public_stacks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_submission_blocklist_events": {
+      "name": "public_submission_blocklist_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blocklist_entry_id": {
+          "name": "blocklist_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matched_type": {
+          "name": "matched_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matched_value": {
+          "name": "matched_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_public_submission_blocklist_events_created_at": {
+          "name": "idx_public_submission_blocklist_events_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_submission_blocklist_events_entry": {
+          "name": "idx_public_submission_blocklist_events_entry",
+          "columns": [
+            {
+              "expression": "blocklist_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_submission_blocklist_events_blocklist_entry_id_public_submission_blocklist_id_fk": {
+          "name": "public_submission_blocklist_events_blocklist_entry_id_public_submission_blocklist_id_fk",
+          "tableFrom": "public_submission_blocklist_events",
+          "tableTo": "public_submission_blocklist",
+          "columnsFrom": ["blocklist_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "public_submission_blocklist_events_submitted_by_user_id_users_id_fk": {
+          "name": "public_submission_blocklist_events_submitted_by_user_id_users_id_fk",
+          "tableFrom": "public_submission_blocklist_events",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.public_submission_blocklist": {
+      "name": "public_submission_blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_value": {
+          "name": "normalized_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_public_submission_blocklist_match": {
+          "name": "unique_public_submission_blocklist_match",
+          "columns": [
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_public_submission_blocklist_created_at": {
+          "name": "idx_public_submission_blocklist_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_submission_blocklist_created_by_users_id_fk": {
+          "name": "public_submission_blocklist_created_by_users_id_fk",
+          "tableFrom": "public_submission_blocklist",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "public_submission_blocklist_value_check": {
+          "name": "public_submission_blocklist_value_check",
+          "value": "length(btrim(\"public_submission_blocklist\".\"normalized_value\")) > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.public_submission_rate_limits": {
+      "name": "public_submission_rate_limits",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_public_submission_rate_limits_updated_at": {
+          "name": "idx_public_submission_rate_limits_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "public_submission_rate_limits_attempt_count_check": {
+          "name": "public_submission_rate_limits_attempt_count_check",
+          "value": "\"public_submission_rate_limits\".\"attempt_count\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resources_normalized_url_unique": {
+          "name": "resources_normalized_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["normalized_url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tool_listings": {
+      "name": "tool_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_source": {
+          "name": "image_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_github_url": {
+          "name": "submitter_github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_code": {
+          "name": "rejection_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_listings_status_created": {
+          "name": "idx_tool_listings_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_tool_listing_resource": {
+          "name": "unique_tool_listing_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tool_listings_resource_id_resources_id_fk": {
+          "name": "tool_listings_resource_id_resources_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_listings_submitted_by_user_id_users_id_fk": {
+          "name": "tool_listings_submitted_by_user_id_users_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_listings_reviewed_by_users_id_fk": {
+          "name": "tool_listings_reviewed_by_users_id_fk",
+          "tableFrom": "tool_listings",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "highlight_color": {
+          "name": "highlight_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_role": {
+          "name": "unique_user_role",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/postgres/meta/0010_snapshot.json
+++ b/migrations/postgres/meta/0010_snapshot.json
@@ -1201,6 +1201,10 @@
         "public_submission_blocklist_value_check": {
           "name": "public_submission_blocklist_value_check",
           "value": "length(btrim(\"public_submission_blocklist\".\"normalized_value\")) > 0"
+        },
+        "public_submission_blocklist_match_type_check": {
+          "name": "public_submission_blocklist_match_type_check",
+          "value": "\"public_submission_blocklist\".\"match_type\" in ('url', 'domain')"
         }
       },
       "isRLSEnabled": true

--- a/migrations/postgres/meta/_journal.json
+++ b/migrations/postgres/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1783804190694,
       "tag": "0009_rich_supernaut",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1783980782994,
+      "tag": "0010_lame_rage",
+      "breakpoints": true
     }
   ]
 }

--- a/netlify/functions/__tests__/admin-blocklist.test.ts
+++ b/netlify/functions/__tests__/admin-blocklist.test.ts
@@ -38,7 +38,8 @@ const entry = {
   createdAt: new Date("2026-07-14T08:00:00.000Z"),
 };
 
-function createRequest(method: string, body?: unknown) {
+/** Creates an admin blocklist Request with the given method and optional body. */
+function createRequest(method: string, body?: unknown): Request {
   return new Request("https://test.com/api/admin/blocklist", {
     method,
     headers: {

--- a/netlify/functions/__tests__/admin-blocklist.test.ts
+++ b/netlify/functions/__tests__/admin-blocklist.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth", () => ({
+  verifyAuthenticatedUser: vi.fn(),
+}));
+
+vi.mock("../lib/submission-blocklist", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../lib/submission-blocklist")>();
+  return {
+    ...actual,
+    createSubmissionBlocklistEntry: vi.fn(),
+    deleteSubmissionBlocklistEntry: vi.fn(),
+    listSubmissionBlocklistEntries: vi.fn(),
+    listSubmissionBlocklistEvents: vi.fn(),
+  };
+});
+
+import adminBlocklist from "../admin-blocklist.mts";
+import { verifyAuthenticatedUser } from "../lib/auth";
+import {
+  createSubmissionBlocklistEntry,
+  deleteSubmissionBlocklistEntry,
+  listSubmissionBlocklistEntries,
+  listSubmissionBlocklistEvents,
+} from "../lib/submission-blocklist";
+import { createMockContext } from "./test-utils";
+
+const adminAuth = {
+  user: { id: "11111111-1111-4111-8111-111111111111" },
+  isAdmin: true,
+};
+const entry = {
+  id: "22222222-2222-4222-8222-222222222222",
+  matchType: "domain" as const,
+  value: "www.example.com",
+  normalizedValue: "example.com",
+  createdAt: new Date("2026-07-14T08:00:00.000Z"),
+};
+
+function createRequest(method: string, body?: unknown) {
+  return new Request("https://test.com/api/admin/blocklist", {
+    method,
+    headers: {
+      Authorization: "Bearer token",
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("admin-blocklist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(verifyAuthenticatedUser).mockResolvedValue(adminAuth as never);
+    vi.mocked(listSubmissionBlocklistEvents).mockResolvedValue([]);
+  });
+
+  it.each(["GET", "POST", "DELETE"])(
+    "requires authentication for %s requests",
+    async (method) => {
+      vi.mocked(verifyAuthenticatedUser).mockResolvedValue(null);
+
+      const response = await adminBlocklist(
+        createRequest(method),
+        createMockContext(),
+      );
+
+      expect(response.status).toBe(401);
+      expect(listSubmissionBlocklistEntries).not.toHaveBeenCalled();
+    },
+  );
+
+  it("requires an admin role", async () => {
+    vi.mocked(verifyAuthenticatedUser).mockResolvedValue({
+      ...adminAuth,
+      isAdmin: false,
+    } as never);
+
+    const response = await adminBlocklist(
+      createRequest("GET"),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("lists private blocklist entries", async () => {
+    vi.mocked(listSubmissionBlocklistEntries).mockResolvedValue([entry]);
+
+    const response = await adminBlocklist(
+      createRequest("GET"),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        entries: [{ normalizedValue: "example.com" }],
+        recentEvents: [],
+      },
+    });
+  });
+
+  it("creates a normalized blocklist entry", async () => {
+    vi.mocked(createSubmissionBlocklistEntry).mockResolvedValue({
+      outcome: "created",
+      entry,
+    });
+
+    const response = await adminBlocklist(
+      createRequest("POST", { matchType: "domain", value: "www.example.com" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(201);
+    expect(createSubmissionBlocklistEntry).toHaveBeenCalledWith(
+      { matchType: "domain", value: "www.example.com" },
+      adminAuth.user.id,
+    );
+  });
+
+  it("returns a conflict for duplicate rules", async () => {
+    vi.mocked(createSubmissionBlocklistEntry).mockResolvedValue({
+      outcome: "duplicate",
+    });
+
+    const response = await adminBlocklist(
+      createRequest("POST", { matchType: "domain", value: "example.com" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  it("rejects malformed domain rules", async () => {
+    vi.mocked(createSubmissionBlocklistEntry).mockResolvedValue({
+      outcome: "invalid",
+    });
+
+    const response = await adminBlocklist(
+      createRequest("POST", { matchType: "domain", value: "example.com/path" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("without a path"),
+    });
+  });
+
+  it("removes a rule while preserving audit history in the data layer", async () => {
+    vi.mocked(deleteSubmissionBlocklistEntry).mockResolvedValue(true);
+
+    const response = await adminBlocklist(
+      createRequest("DELETE", { id: entry.id }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(deleteSubmissionBlocklistEntry).toHaveBeenCalledWith(entry.id);
+  });
+});

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -501,6 +501,37 @@ describe("public-submissions", () => {
     expect(mockDb.insert).not.toHaveBeenCalled();
   });
 
+  it("fails closed when the submission blocklist store is unavailable", async () => {
+    vi.mocked(findSubmissionBlocklistMatch).mockRejectedValueOnce(
+      new Error("blocklist datastore unavailable"),
+    );
+
+    try {
+      const res = await publicSubmissions(
+        createSubmissionRequest({
+          type: "resource",
+          url: "https://example.com/dependency-error",
+          tags: ["security"],
+        }),
+        createMockContext(),
+      );
+
+      expect(res.status).toBe(503);
+      await expect(res.json()).resolves.toEqual({
+        success: false,
+        error: "Service temporarily unavailable",
+      });
+      expect(captureError).toHaveBeenCalledWith(expect.any(Error), {
+        function: "public-submissions",
+        dependency: "submission-blocklist-store",
+      });
+      expect(flushSentry).toHaveBeenCalledOnce();
+      expect(extractMetadata).not.toHaveBeenCalled();
+    } finally {
+      vi.mocked(findSubmissionBlocklistMatch).mockResolvedValue(null);
+    }
+  });
+
   it("returns a clear duplicate conflict", async () => {
     const mockDb = createMockDb();
     mockDb.returning

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -20,6 +20,16 @@ vi.mock("../lib/sentry", () => ({
   flushSentry: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../lib/submission-blocklist", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../lib/submission-blocklist")>();
+  return {
+    ...actual,
+    findSubmissionBlocklistMatch: vi.fn(),
+    recordSubmissionBlocklistEvent: vi.fn(),
+  };
+});
+
 vi.mock("../../../src/lib/services/metadata", () => ({
   extractMetadata: vi.fn(),
 }));
@@ -41,6 +51,10 @@ import { verifyAuthenticatedUser } from "../lib/auth";
 import { getDb } from "../lib/db";
 import { captureError, flushSentry } from "../lib/sentry";
 import { createSubmissionRateLimitKey } from "../lib/submission-rate-limit";
+import {
+  findSubmissionBlocklistMatch,
+  recordSubmissionBlocklistEvent,
+} from "../lib/submission-blocklist";
 import { lookup } from "node:dns/promises";
 import { captureScreenshot } from "../../../src/lib/services/screenshot";
 import { uploadScreenshot } from "../../../src/lib/services/cloudinary";
@@ -92,6 +106,8 @@ describe("public-submissions", () => {
     ] as never);
 
     vi.mocked(verifyAuthenticatedUser).mockResolvedValue(null);
+    vi.mocked(findSubmissionBlocklistMatch).mockResolvedValue(null);
+    vi.mocked(recordSubmissionBlocklistEvent).mockResolvedValue(undefined);
     vi.mocked(extractMetadata).mockResolvedValue({
       title: "Example title",
       description: "Example description",
@@ -448,6 +464,41 @@ describe("public-submissions", () => {
 
     expect(res.status).toBe(422);
     expect(extractMetadata).not.toHaveBeenCalled();
+  });
+
+  it("rejects a blocklisted URL generically before DNS, metadata, or inserts", async () => {
+    const mockDb = createMockDb();
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+    vi.mocked(findSubmissionBlocklistMatch).mockResolvedValueOnce({
+      id: "11111111-1111-4111-8111-111111111111",
+      matchType: "domain",
+      normalizedValue: "example.com",
+    });
+
+    const res = await publicSubmissions(
+      createSubmissionRequest({
+        type: "resource",
+        url: "https://www.example.com/blocked",
+        tags: ["security"],
+      }),
+      createMockContext(),
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      success: false,
+      error: "This resource cannot be submitted.",
+    });
+    expect(recordSubmissionBlocklistEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ normalizedValue: "example.com" }),
+      "https://www.example.com/blocked",
+      null,
+    );
+    expect(lookup).not.toHaveBeenCalled();
+    expect(extractMetadata).not.toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
   });
 
   it("returns a clear duplicate conflict", async () => {

--- a/netlify/functions/__tests__/rls-migration.test.ts
+++ b/netlify/functions/__tests__/rls-migration.test.ts
@@ -16,6 +16,10 @@ const existingPolicies = readFileSync(
   ),
   "utf8",
 );
+const blocklistMigration = readFileSync(
+  new URL("../../../migrations/postgres/0010_lame_rage.sql", import.meta.url),
+  "utf8",
+);
 
 /** Extracts one statement from a Drizzle SQL migration. */
 function migrationStatement(sql: string, statementStart: string): string {
@@ -111,5 +115,21 @@ describe("RLS migration SQL contract", () => {
         migrationStatement(existingPolicies, `CREATE POLICY "${policy}"`),
       ).toContain("public.is_admin()");
     }
+  });
+
+  it("keeps blocklist rules and audit events inaccessible to browser roles", () => {
+    for (const table of [
+      "public_submission_blocklist",
+      "public_submission_blocklist_events",
+    ]) {
+      expect(blocklistMigration).toContain(
+        `ALTER TABLE "${table}" ENABLE ROW LEVEL SECURITY;`,
+      );
+      expect(blocklistMigration).toContain(
+        `REVOKE ALL ON TABLE "${table}" FROM anon, authenticated;`,
+      );
+    }
+
+    expect(blocklistMigration).not.toMatch(/CREATE POLICY|GRANT /i);
   });
 });

--- a/netlify/functions/admin-blocklist.mts
+++ b/netlify/functions/admin-blocklist.mts
@@ -1,0 +1,120 @@
+import type { Config, Context } from "@netlify/functions";
+import type { BaseIssue } from "valibot";
+import * as v from "valibot";
+
+import {
+  badRequest,
+  conflict,
+  created,
+  forbidden,
+  methodNotAllowed,
+  notFound,
+  ok,
+  serverError,
+  unauthorized,
+  validationError,
+} from "./lib";
+import { verifyAuthenticatedUser } from "./lib/auth";
+import {
+  blocklistDeleteRequestSchema,
+  blocklistEntryRequestSchema,
+  createSubmissionBlocklistEntry,
+  deleteSubmissionBlocklistEntry,
+  listSubmissionBlocklistEntries,
+  listSubmissionBlocklistEvents,
+} from "./lib/submission-blocklist";
+
+function getValidationDetails(issues: readonly BaseIssue<unknown>[]) {
+  return issues.reduce<Record<string, string[]>>((details, issue) => {
+    const field = issue.path?.map((item) => item.key).join(".") || "form";
+    details[field] ??= [];
+    details[field].push(issue.message);
+    return details;
+  }, {});
+}
+
+async function parseRequest(req: Request): Promise<unknown | Response> {
+  try {
+    return await req.json();
+  } catch {
+    return validationError("Invalid JSON in request body");
+  }
+}
+
+export default async (req: Request, _context: Context) => {
+  if (
+    req.method !== "GET" &&
+    req.method !== "POST" &&
+    req.method !== "DELETE"
+  ) {
+    return methodNotAllowed(["GET", "POST", "DELETE"]);
+  }
+
+  try {
+    const auth = await verifyAuthenticatedUser(req);
+    if (!auth) {
+      return unauthorized();
+    }
+    if (!auth.isAdmin) {
+      return forbidden("Admin access required");
+    }
+
+    if (req.method === "GET") {
+      const [entries, recentEvents] = await Promise.all([
+        listSubmissionBlocklistEntries(),
+        listSubmissionBlocklistEvents(),
+      ]);
+      return ok({ entries, recentEvents });
+    }
+
+    const body = await parseRequest(req);
+    if (body instanceof Response) {
+      return body;
+    }
+
+    if (req.method === "POST") {
+      const parsed = v.safeParse(blocklistEntryRequestSchema, body);
+      if (!parsed.success) {
+        return validationError(
+          "Validation failed",
+          getValidationDetails(parsed.issues),
+        );
+      }
+
+      const result = await createSubmissionBlocklistEntry(
+        parsed.output,
+        auth.user.id,
+      );
+      if (result.outcome === "invalid") {
+        return badRequest(
+          parsed.output.matchType === "domain"
+            ? "Enter a domain without a path, query, or fragment"
+            : "Enter a valid HTTP/HTTPS URL",
+        );
+      }
+      if (result.outcome === "duplicate") {
+        return conflict("This blocklist rule already exists");
+      }
+      return created(result.entry);
+    }
+
+    const parsed = v.safeParse(blocklistDeleteRequestSchema, body);
+    if (!parsed.success) {
+      return validationError(
+        "Validation failed",
+        getValidationDetails(parsed.issues),
+      );
+    }
+
+    return (await deleteSubmissionBlocklistEntry(parsed.output.id))
+      ? ok({ id: parsed.output.id })
+      : notFound("Blocklist rule not found");
+  } catch (error) {
+    console.error("[admin-blocklist]", error);
+    return serverError("An error occurred while managing the blocklist");
+  }
+};
+
+export const config: Config = {
+  path: "/api/admin/blocklist",
+};

--- a/netlify/functions/admin-blocklist.mts
+++ b/netlify/functions/admin-blocklist.mts
@@ -4,8 +4,10 @@ import * as v from "valibot";
 
 import {
   badRequest,
+  captureError,
   conflict,
   created,
+  flushSentry,
   forbidden,
   methodNotAllowed,
   notFound,
@@ -110,7 +112,11 @@ export default async (req: Request, _context: Context) => {
       ? ok({ id: parsed.output.id })
       : notFound("Blocklist rule not found");
   } catch (error) {
-    console.error("[admin-blocklist]", error);
+    captureError(error, {
+      function: "admin-blocklist",
+      requestId: _context.requestId,
+    });
+    await flushSentry();
     return serverError("An error occurred while managing the blocklist");
   }
 };

--- a/netlify/functions/lib/__tests__/submission-blocklist.test.ts
+++ b/netlify/functions/lib/__tests__/submission-blocklist.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../db", () => ({
+  getDb: vi.fn(),
+}));
+
+import {
+  normalizeBlocklistValue,
+  recordSubmissionBlocklistEvent,
+  submissionMatchesBlocklistRule,
+} from "../submission-blocklist";
+import { getDb } from "../db";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("submission blocklist normalization", () => {
+  it("normalizes exact URLs consistently", () => {
+    expect(
+      normalizeBlocklistValue(
+        "url",
+        "HTTPS://Example.COM:443/path/?b=2&a=1#fragment",
+      ),
+    ).toBe("https://example.com/path?a=1&b=2");
+  });
+
+  it("normalizes common domain variants", () => {
+    expect(normalizeBlocklistValue("domain", "WWW.Example.COM.")).toBe(
+      "example.com",
+    );
+    expect(normalizeBlocklistValue("domain", "https://www.example.com")).toBe(
+      "example.com",
+    );
+  });
+
+  it("rejects domain rules with URL-specific parts", () => {
+    expect(normalizeBlocklistValue("domain", "example.com/path")).toBeNull();
+    expect(normalizeBlocklistValue("domain", "example.com?probe=1")).toBeNull();
+  });
+});
+
+describe("submission blocklist matching", () => {
+  it("matches exact URLs after normalization but preserves meaningful queries", () => {
+    const rule = {
+      matchType: "url" as const,
+      normalizedValue: "https://example.com/path?a=1&b=2",
+    };
+
+    expect(
+      submissionMatchesBlocklistRule(
+        "https://EXAMPLE.com/path/?b=2&a=1#ignored",
+        rule,
+      ),
+    ).toBe(true);
+    expect(
+      submissionMatchesBlocklistRule("https://example.com/path?a=2&b=2", rule),
+    ).toBe(false);
+  });
+
+  it("matches a domain, www variant, and subdomains without suffix collisions", () => {
+    const rule = {
+      matchType: "domain" as const,
+      normalizedValue: "example.com",
+    };
+
+    expect(
+      submissionMatchesBlocklistRule("https://www.example.com", rule),
+    ).toBe(true);
+    expect(
+      submissionMatchesBlocklistRule("https://docs.example.com/path", rule),
+    ).toBe(true);
+    expect(submissionMatchesBlocklistRule("https://notexample.com", rule)).toBe(
+      false,
+    );
+  });
+
+  it("redacts credentials, queries, and fragments from audit URLs", async () => {
+    const values = vi.fn().mockResolvedValue(undefined);
+    const mockDb = { insert: vi.fn(() => ({ values })) };
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+
+    await recordSubmissionBlocklistEvent(
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        matchType: "domain",
+        normalizedValue: "example.com",
+      },
+      "https://user:secret@example.com/blocked?token=sensitive#fragment",
+      null,
+    );
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ normalizedUrl: "https://example.com/blocked" }),
+    );
+  });
+});

--- a/netlify/functions/lib/__tests__/submission-blocklist.test.ts
+++ b/netlify/functions/lib/__tests__/submission-blocklist.test.ts
@@ -5,11 +5,13 @@ vi.mock("../db", () => ({
 }));
 
 import {
+  findSubmissionBlocklistMatch,
   normalizeBlocklistValue,
   recordSubmissionBlocklistEvent,
   submissionMatchesBlocklistRule,
 } from "../submission-blocklist";
 import { getDb } from "../db";
+import { getPgQuery } from "../../__tests__/test-utils";
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -39,6 +41,49 @@ describe("submission blocklist normalization", () => {
 });
 
 describe("submission blocklist matching", () => {
+  it("finds underscore-containing domain rules using a literal LIKE suffix", async () => {
+    const rule = {
+      id: "11111111-1111-4111-8111-111111111111",
+      matchType: "domain" as const,
+      normalizedValue: "under_score.example.com",
+    };
+    const mockDb = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([rule]),
+    };
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+
+    await expect(
+      findSubmissionBlocklistMatch(
+        "https://docs.under_score.example.com/resource",
+      ),
+    ).resolves.toEqual(rule);
+
+    const query = getPgQuery(mockDb.where.mock.calls[0][0]);
+    expect(query.sql).toContain("replace(");
+    expect(query.sql).toContain("escape chr(92)");
+  });
+
+  it("returns null when the database query has no matching rule", async () => {
+    const mockDb = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+
+    await expect(
+      findSubmissionBlocklistMatch("https://allowed.example.com"),
+    ).resolves.toBeNull();
+  });
+
   it("matches exact URLs after normalization but preserves meaningful queries", () => {
     const rule = {
       matchType: "url" as const,

--- a/netlify/functions/lib/index.ts
+++ b/netlify/functions/lib/index.ts
@@ -27,5 +27,7 @@ export {
   publicStacksTable,
   publicStackItemsTable,
   publicSubmissionRateLimitsTable,
+  publicSubmissionBlocklistTable,
+  publicSubmissionBlocklistEventsTable,
   userRolesTable,
 } from "../../../src/db/schema";

--- a/netlify/functions/lib/submission-blocklist.ts
+++ b/netlify/functions/lib/submission-blocklist.ts
@@ -1,0 +1,226 @@
+import { and, desc, eq, or, sql } from "drizzle-orm";
+import * as v from "valibot";
+
+import {
+  publicSubmissionBlocklistEventsTable,
+  publicSubmissionBlocklistTable,
+} from "../../../src/db/schema";
+import { getDb } from "./db";
+import { normalizeUrl, parseAndNormalizeUrl } from "./url";
+
+export const blocklistMatchTypeSchema = v.picklist(["url", "domain"]);
+export const blocklistEntryRequestSchema = v.strictObject({
+  matchType: blocklistMatchTypeSchema,
+  value: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, "A URL or domain is required"),
+    v.maxLength(2000, "The value must be 2000 characters or less"),
+  ),
+});
+export const blocklistDeleteRequestSchema = v.strictObject({
+  id: v.pipe(v.string(), v.uuid()),
+});
+
+export type BlocklistMatchType = v.InferOutput<typeof blocklistMatchTypeSchema>;
+
+export interface BlocklistMatch {
+  id: string;
+  matchType: BlocklistMatchType;
+  normalizedValue: string;
+}
+
+function normalizeDomain(value: string): string | null {
+  const candidate = value.includes("://") ? value : `https://${value}`;
+
+  try {
+    const url = new URL(candidate);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username ||
+      url.password ||
+      (url.pathname !== "/" && url.pathname !== "") ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+
+    return (
+      url.hostname
+        .toLowerCase()
+        .replace(/^www\./, "")
+        .replace(/\.$/, "") || null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** Normalizes an admin-supplied blocklist value for stable matching. */
+export function normalizeBlocklistValue(
+  matchType: BlocklistMatchType,
+  value: string,
+): string | null {
+  if (matchType === "domain") {
+    return normalizeDomain(value.trim());
+  }
+
+  return parseAndNormalizeUrl(value.trim());
+}
+
+function getNormalizedSubmissionDomain(normalizedUrl: string): string {
+  return new URL(normalizedUrl).hostname
+    .toLowerCase()
+    .replace(/^www\./, "")
+    .replace(/\.$/, "");
+}
+
+/** Applies normalized exact-URL and parent-domain matching rules. */
+export function submissionMatchesBlocklistRule(
+  submittedUrl: string,
+  rule: Pick<BlocklistMatch, "matchType" | "normalizedValue">,
+): boolean {
+  const normalizedUrl = normalizeUrl(submittedUrl);
+  if (rule.matchType === "url") {
+    return normalizedUrl === rule.normalizedValue;
+  }
+
+  const domain = getNormalizedSubmissionDomain(normalizedUrl);
+  return (
+    domain === rule.normalizedValue ||
+    domain.endsWith(`.${rule.normalizedValue}`)
+  );
+}
+
+/** Finds the first exact-URL or parent-domain rule matching a submission. */
+export async function findSubmissionBlocklistMatch(
+  submittedUrl: string,
+): Promise<BlocklistMatch | null> {
+  const normalizedUrl = normalizeUrl(submittedUrl);
+  const normalizedDomain = getNormalizedSubmissionDomain(normalizedUrl);
+  const [match] = await getDb()
+    .select({
+      id: publicSubmissionBlocklistTable.id,
+      matchType: publicSubmissionBlocklistTable.matchType,
+      normalizedValue: publicSubmissionBlocklistTable.normalizedValue,
+    })
+    .from(publicSubmissionBlocklistTable)
+    .where(
+      or(
+        and(
+          eq(publicSubmissionBlocklistTable.matchType, "url"),
+          eq(publicSubmissionBlocklistTable.normalizedValue, normalizedUrl),
+        ),
+        and(
+          eq(publicSubmissionBlocklistTable.matchType, "domain"),
+          or(
+            eq(
+              publicSubmissionBlocklistTable.normalizedValue,
+              normalizedDomain,
+            ),
+            sql`${normalizedDomain} like ('%.' || ${publicSubmissionBlocklistTable.normalizedValue})`,
+          ),
+        ),
+      ),
+    )
+    .limit(1);
+
+  return match && submissionMatchesBlocklistRule(normalizedUrl, match)
+    ? match
+    : null;
+}
+
+/** Records a private audit event for a blocked submission attempt. */
+export async function recordSubmissionBlocklistEvent(
+  match: BlocklistMatch,
+  normalizedUrl: string,
+  submittedByUserId: string | null,
+): Promise<void> {
+  const auditUrl = new URL(normalizedUrl);
+  auditUrl.username = "";
+  auditUrl.password = "";
+  auditUrl.search = "";
+  auditUrl.hash = "";
+
+  await getDb().insert(publicSubmissionBlocklistEventsTable).values({
+    blocklistEntryId: match.id,
+    normalizedUrl: auditUrl.toString(),
+    matchedType: match.matchType,
+    matchedValue: match.normalizedValue,
+    submittedByUserId,
+  });
+}
+
+/** Returns blocklist rules newest-first for the admin moderation surface. */
+export async function listSubmissionBlocklistEntries() {
+  return await getDb()
+    .select({
+      id: publicSubmissionBlocklistTable.id,
+      matchType: publicSubmissionBlocklistTable.matchType,
+      value: publicSubmissionBlocklistTable.value,
+      normalizedValue: publicSubmissionBlocklistTable.normalizedValue,
+      createdAt: publicSubmissionBlocklistTable.createdAt,
+    })
+    .from(publicSubmissionBlocklistTable)
+    .orderBy(desc(publicSubmissionBlocklistTable.createdAt));
+}
+
+/** Returns recent redacted matches so admins can understand enforcement. */
+export async function listSubmissionBlocklistEvents() {
+  return await getDb()
+    .select({
+      id: publicSubmissionBlocklistEventsTable.id,
+      normalizedUrl: publicSubmissionBlocklistEventsTable.normalizedUrl,
+      matchedType: publicSubmissionBlocklistEventsTable.matchedType,
+      matchedValue: publicSubmissionBlocklistEventsTable.matchedValue,
+      createdAt: publicSubmissionBlocklistEventsTable.createdAt,
+    })
+    .from(publicSubmissionBlocklistEventsTable)
+    .orderBy(desc(publicSubmissionBlocklistEventsTable.createdAt))
+    .limit(50);
+}
+
+/** Creates a normalized blocklist rule, returning null for a duplicate. */
+export async function createSubmissionBlocklistEntry(
+  input: v.InferOutput<typeof blocklistEntryRequestSchema>,
+  createdBy: string,
+) {
+  const normalizedValue = normalizeBlocklistValue(input.matchType, input.value);
+  if (!normalizedValue) {
+    return { outcome: "invalid" as const };
+  }
+
+  const [entry] = await getDb()
+    .insert(publicSubmissionBlocklistTable)
+    .values({
+      matchType: input.matchType,
+      value: input.value,
+      normalizedValue,
+      createdBy,
+    })
+    .onConflictDoNothing()
+    .returning({
+      id: publicSubmissionBlocklistTable.id,
+      matchType: publicSubmissionBlocklistTable.matchType,
+      value: publicSubmissionBlocklistTable.value,
+      normalizedValue: publicSubmissionBlocklistTable.normalizedValue,
+      createdAt: publicSubmissionBlocklistTable.createdAt,
+    });
+
+  return entry
+    ? { outcome: "created" as const, entry }
+    : { outcome: "duplicate" as const };
+}
+
+/** Deletes a blocklist rule without deleting its historical audit events. */
+export async function deleteSubmissionBlocklistEntry(
+  id: string,
+): Promise<boolean> {
+  const deleted = await getDb()
+    .delete(publicSubmissionBlocklistTable)
+    .where(eq(publicSubmissionBlocklistTable.id, id))
+    .returning({ id: publicSubmissionBlocklistTable.id });
+
+  return deleted.length > 0;
+}

--- a/netlify/functions/lib/submission-blocklist.ts
+++ b/netlify/functions/lib/submission-blocklist.ts
@@ -119,7 +119,7 @@ export async function findSubmissionBlocklistMatch(
               publicSubmissionBlocklistTable.normalizedValue,
               normalizedDomain,
             ),
-            sql`${normalizedDomain} like ('%.' || ${publicSubmissionBlocklistTable.normalizedValue})`,
+            sql`${normalizedDomain} like ('%.' || replace(${publicSubmissionBlocklistTable.normalizedValue}, '_', chr(92) || '_')) escape chr(92)`,
           ),
         ),
       ),

--- a/netlify/functions/lib/submissions.ts
+++ b/netlify/functions/lib/submissions.ts
@@ -19,6 +19,7 @@ import {
   conflict,
   created,
   dependencyUnavailable,
+  forbidden,
   methodNotAllowed,
   serverError,
   tooManyRequests,
@@ -32,6 +33,10 @@ import {
   getSubmissionRateLimitConfig,
   type SubmissionRateLimitConfig,
 } from "./submission-rate-limit";
+import {
+  findSubmissionBlocklistMatch,
+  recordSubmissionBlocklistEvent,
+} from "./submission-blocklist";
 import { normalizeUrl, parseAndNormalizeUrl } from "./url";
 import {
   publicListingsTable,
@@ -289,7 +294,10 @@ function normalizeSubmitterName(
 function resolveSubmissionAttribution(
   submission: PublicSubmissionRequest,
   authenticated: AuthenticatedUser | null,
-): Pick<SubmissionContext, "normalizedSubmitterGithubUrl" | "normalizedSubmitterName"> {
+): Pick<
+  SubmissionContext,
+  "normalizedSubmitterGithubUrl" | "normalizedSubmitterName"
+> {
   const githubUsername = authenticated
     ? getVerifiedGithubUsername(authenticated.user)
     : null;
@@ -306,7 +314,10 @@ function resolveSubmissionAttribution(
 
 /** Returns structured errors when the resolved public attribution is incomplete. */
 function getAttributionValidationDetails(
-  attribution: Pick<SubmissionContext, "normalizedSubmitterGithubUrl" | "normalizedSubmitterName">,
+  attribution: Pick<
+    SubmissionContext,
+    "normalizedSubmitterGithubUrl" | "normalizedSubmitterName"
+  >,
 ): Record<string, string[]> | null {
   const details: Record<string, string[]> = {};
 
@@ -547,6 +558,25 @@ export async function handlePublicSubmission(
     });
   }
 
+  try {
+    const blocklistMatch = await findSubmissionBlocklistMatch(normalizedUrl);
+    if (blocklistMatch) {
+      await recordSubmissionBlocklistEvent(
+        blocklistMatch,
+        normalizedUrl,
+        authenticated?.user.id ?? null,
+      );
+      return forbidden("This resource cannot be submitted.");
+    }
+  } catch (error) {
+    captureError(error, {
+      function: options.endpointName,
+      dependency: "submission-blocklist-store",
+    });
+    await flushSentry();
+    return dependencyUnavailable();
+  }
+
   const publicUrl = await resolvePublicHttpUrl(normalizedUrl);
   if (!publicUrl) {
     return validationError("Validation failed", {
@@ -561,7 +591,10 @@ export async function handlePublicSubmission(
     });
   }
 
-  const attribution = resolveSubmissionAttribution(validation.output, authenticated);
+  const attribution = resolveSubmissionAttribution(
+    validation.output,
+    authenticated,
+  );
   const attributionDetails = getAttributionValidationDetails(attribution);
   if (attributionDetails) {
     return validationError("Validation failed", attributionDetails);

--- a/src/api/__tests__/admin.test.ts
+++ b/src/api/__tests__/admin.test.ts
@@ -77,6 +77,27 @@ describe("submission blocklist API", () => {
     });
   });
 
+  it("throws a typed error when creating a rule fails", async () => {
+    server.use(
+      http.post(`${API_BASE}/api/admin/blocklist`, () =>
+        HttpResponse.json(
+          { success: false, error: "This blocklist rule already exists" },
+          { status: 409 },
+        ),
+      ),
+    );
+
+    await expect(
+      createSubmissionBlocklistRule("admin-token", {
+        matchType: "domain",
+        value: "example.com",
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      message: "This blocklist rule already exists",
+    });
+  });
+
   it("sends authenticated delete requests", async () => {
     let authorization: string | null = null;
     let requestBody: unknown;

--- a/src/api/__tests__/admin.test.ts
+++ b/src/api/__tests__/admin.test.ts
@@ -1,0 +1,112 @@
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { server } from "../../test/mocks/server";
+import {
+  createSubmissionBlocklistRule,
+  deleteSubmissionBlocklistRule,
+  getSubmissionBlocklist,
+} from "../admin";
+
+const API_BASE = "http://localhost:8888";
+const entry = {
+  id: "11111111-1111-4111-8111-111111111111",
+  matchType: "domain",
+  value: "www.example.com",
+  normalizedValue: "example.com",
+  createdAt: "2026-07-14T08:00:00.000Z",
+};
+const recentEvent = {
+  id: "22222222-2222-4222-8222-222222222222",
+  normalizedUrl: "https://example.com/blocked",
+  matchedType: "domain",
+  matchedValue: "example.com",
+  createdAt: "2026-07-14T08:30:00.000Z",
+};
+
+beforeEach(() => {
+  server.use(
+    http.get(`${API_BASE}/api/admin/blocklist`, () =>
+      HttpResponse.json({
+        success: true,
+        data: { entries: [entry], recentEvents: [recentEvent] },
+      }),
+    ),
+    http.post(`${API_BASE}/api/admin/blocklist`, () =>
+      HttpResponse.json({ success: true, data: entry }, { status: 201 }),
+    ),
+    http.delete(`${API_BASE}/api/admin/blocklist`, () =>
+      HttpResponse.json({ success: true, data: { id: entry.id } }),
+    ),
+  );
+});
+
+afterEach(() => server.resetHandlers());
+
+describe("submission blocklist API", () => {
+  it("lists and validates blocklist entries", async () => {
+    await expect(getSubmissionBlocklist("admin-token")).resolves.toEqual({
+      entries: [entry],
+      recentEvents: [recentEvent],
+    });
+  });
+
+  it("sends authenticated create requests", async () => {
+    let authorization: string | null = null;
+    let requestBody: unknown;
+    server.use(
+      http.post(`${API_BASE}/api/admin/blocklist`, async ({ request }) => {
+        authorization = request.headers.get("Authorization");
+        requestBody = await request.json();
+        return HttpResponse.json(
+          { success: true, data: entry },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await createSubmissionBlocklistRule("admin-token", {
+      matchType: "domain",
+      value: "www.example.com",
+    });
+
+    expect(authorization).toBe("Bearer admin-token");
+    expect(requestBody).toEqual({
+      matchType: "domain",
+      value: "www.example.com",
+    });
+  });
+
+  it("sends authenticated delete requests", async () => {
+    let authorization: string | null = null;
+    let requestBody: unknown;
+    server.use(
+      http.delete(`${API_BASE}/api/admin/blocklist`, async ({ request }) => {
+        authorization = request.headers.get("Authorization");
+        requestBody = await request.json();
+        return HttpResponse.json({ success: true, data: { id: entry.id } });
+      }),
+    );
+
+    await deleteSubmissionBlocklistRule("admin-token", entry.id);
+
+    expect(authorization).toBe("Bearer admin-token");
+    expect(requestBody).toEqual({ id: entry.id });
+  });
+
+  it("rejects malformed success responses", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/admin/blocklist`, () =>
+        HttpResponse.json({
+          success: true,
+          data: { entries: [{ id: "invalid" }] },
+        }),
+      ),
+    );
+
+    await expect(getSubmissionBlocklist("admin-token")).rejects.toMatchObject({
+      status: 500,
+      message: "Invalid response from server",
+    });
+  });
+});

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -2,6 +2,14 @@ import * as v from "valibot";
 
 import { BookmarkApiError } from "./bookmarks";
 
+function getBaseUrl(): string {
+  if (typeof window !== "undefined") {
+    return "";
+  }
+
+  return process.env.API_BASE_URL || "http://localhost:8888";
+}
+
 const moderationEntityTypeSchema = v.picklist([
   "tool",
   "resource",
@@ -132,7 +140,7 @@ export async function getModerationQueue(
   }
 
   const response = await fetch(
-    `/api/admin/moderation?${searchParams.toString()}`,
+    `${getBaseUrl()}/api/admin/moderation?${searchParams.toString()}`,
     {
       headers: getAuthHeaders(accessToken),
       signal,
@@ -156,7 +164,7 @@ export async function reviewModerationItem(
   accessToken: string,
   data: ReviewModerationItemData,
 ): Promise<ModerationReviewResult> {
-  const response = await fetch("/api/admin/moderation", {
+  const response = await fetch(`${getBaseUrl()}/api/admin/moderation`, {
     method: "PATCH",
     headers: {
       ...getAuthHeaders(accessToken),
@@ -183,7 +191,7 @@ export async function getSubmissionBlocklist(
   accessToken: string,
   signal?: AbortSignal,
 ): Promise<{ entries: BlocklistEntry[]; recentEvents: BlocklistEvent[] }> {
-  const response = await fetch("/api/admin/blocklist", {
+  const response = await fetch(`${getBaseUrl()}/api/admin/blocklist`, {
     headers: getAuthHeaders(accessToken),
     signal,
   });
@@ -206,7 +214,7 @@ export async function createSubmissionBlocklistRule(
   accessToken: string,
   data: { matchType: BlocklistMatchType; value: string },
 ): Promise<BlocklistEntry> {
-  const response = await fetch("/api/admin/blocklist", {
+  const response = await fetch(`${getBaseUrl()}/api/admin/blocklist`, {
     method: "POST",
     headers: {
       ...getAuthHeaders(accessToken),
@@ -233,7 +241,7 @@ export async function deleteSubmissionBlocklistRule(
   accessToken: string,
   id: string,
 ): Promise<void> {
-  const response = await fetch("/api/admin/blocklist", {
+  const response = await fetch(`${getBaseUrl()}/api/admin/blocklist`, {
     method: "DELETE",
     headers: {
       ...getAuthHeaders(accessToken),

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -43,6 +43,36 @@ const moderationReviewResponseSchema = v.object({
     status: moderationStatusSchema,
   }),
 });
+const blocklistMatchTypeSchema = v.picklist(["url", "domain"]);
+const blocklistEntrySchema = v.object({
+  id: v.pipe(v.string(), v.uuid()),
+  matchType: blocklistMatchTypeSchema,
+  value: v.string(),
+  normalizedValue: v.string(),
+  createdAt: v.union([v.string(), v.date()]),
+});
+const blocklistEventSchema = v.object({
+  id: v.pipe(v.string(), v.uuid()),
+  normalizedUrl: v.string(),
+  matchedType: blocklistMatchTypeSchema,
+  matchedValue: v.string(),
+  createdAt: v.union([v.string(), v.date()]),
+});
+const blocklistEntriesResponseSchema = v.object({
+  success: v.literal(true),
+  data: v.object({
+    entries: v.array(blocklistEntrySchema),
+    recentEvents: v.array(blocklistEventSchema),
+  }),
+});
+const blocklistEntryResponseSchema = v.object({
+  success: v.literal(true),
+  data: blocklistEntrySchema,
+});
+const blocklistDeleteResponseSchema = v.object({
+  success: v.literal(true),
+  data: v.object({ id: v.pipe(v.string(), v.uuid()) }),
+});
 const errorResponseSchema = v.object({
   success: v.literal(false),
   error: v.string(),
@@ -56,6 +86,9 @@ export type ModerationItem = v.InferOutput<typeof moderationItemSchema>;
 export type ModerationReviewResult = v.InferOutput<
   typeof moderationReviewResponseSchema
 >["data"];
+export type BlocklistMatchType = v.InferOutput<typeof blocklistMatchTypeSchema>;
+export type BlocklistEntry = v.InferOutput<typeof blocklistEntrySchema>;
+export type BlocklistEvent = v.InferOutput<typeof blocklistEventSchema>;
 
 export interface ReviewModerationItemData {
   type: ModerationEntityType;
@@ -143,4 +176,79 @@ export async function reviewModerationItem(
   }
 
   return parsed.output.data;
+}
+
+/** Lists private submission blocklist rules for an authenticated admin. */
+export async function getSubmissionBlocklist(
+  accessToken: string,
+  signal?: AbortSignal,
+): Promise<{ entries: BlocklistEntry[]; recentEvents: BlocklistEvent[] }> {
+  const response = await fetch("/api/admin/blocklist", {
+    headers: getAuthHeaders(accessToken),
+    signal,
+  });
+  const json = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throwApiError(json, response.status);
+  }
+
+  const parsed = v.safeParse(blocklistEntriesResponseSchema, json);
+  if (!parsed.success) {
+    throw new BookmarkApiError("Invalid response from server", 500);
+  }
+
+  return parsed.output.data;
+}
+
+/** Adds a normalized URL or domain rule to the submission blocklist. */
+export async function createSubmissionBlocklistRule(
+  accessToken: string,
+  data: { matchType: BlocklistMatchType; value: string },
+): Promise<BlocklistEntry> {
+  const response = await fetch("/api/admin/blocklist", {
+    method: "POST",
+    headers: {
+      ...getAuthHeaders(accessToken),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  const json = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throwApiError(json, response.status);
+  }
+
+  const parsed = v.safeParse(blocklistEntryResponseSchema, json);
+  if (!parsed.success) {
+    throw new BookmarkApiError("Invalid response from server", 500);
+  }
+
+  return parsed.output.data;
+}
+
+/** Removes a rule while retaining its server-side audit history. */
+export async function deleteSubmissionBlocklistRule(
+  accessToken: string,
+  id: string,
+): Promise<void> {
+  const response = await fetch("/api/admin/blocklist", {
+    method: "DELETE",
+    headers: {
+      ...getAuthHeaders(accessToken),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ id }),
+  });
+  const json = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throwApiError(json, response.status);
+  }
+
+  const parsed = v.safeParse(blocklistDeleteResponseSchema, json);
+  if (!parsed.success) {
+    throw new BookmarkApiError("Invalid response from server", 500);
+  }
 }

--- a/src/components/admin/SubmissionBlocklist.tsx
+++ b/src/components/admin/SubmissionBlocklist.tsx
@@ -1,0 +1,164 @@
+import type { FormEvent } from "react";
+
+import { useAdminBlocklist } from "../../hooks/useAdminBlocklist";
+import { Alert } from "../ui/Alert";
+import { Button } from "../ui/Button";
+
+interface SubmissionBlocklistProps {
+  accessToken: string | null;
+}
+
+/** Admin controls for listing, adding, and removing private submission rules. */
+export function SubmissionBlocklist({ accessToken }: SubmissionBlocklistProps) {
+  const {
+    addEntry,
+    entries,
+    error,
+    isLoading,
+    matchType,
+    pendingEntryId,
+    recentEvents,
+    removeEntry,
+    setError,
+    setMatchType,
+    setSuccessMessage,
+    setValue,
+    successMessage,
+    value,
+  } = useAdminBlocklist({ accessToken, isAdmin: true });
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void addEntry();
+  }
+
+  return (
+    <section
+      className="AdminModerationPage-blocklist"
+      aria-labelledby="submission-blocklist-heading"
+    >
+      <header className="AdminModerationPage-blocklistHeader">
+        <div>
+          <h2 id="submission-blocklist-heading" className="heading-lg">
+            Submission blocklist
+          </h2>
+          <p className="AdminModerationPage-description body-base">
+            Block exact URLs or a domain and all of its subdomains before they
+            enter the moderation queue.
+          </p>
+        </div>
+      </header>
+
+      {error && (
+        <Alert variant="error" dismissible onDismiss={() => setError(null)}>
+          <strong>Blocklist error.</strong> {error}
+        </Alert>
+      )}
+      {successMessage && (
+        <Alert
+          variant="success"
+          dismissible
+          onDismiss={() => setSuccessMessage(null)}
+        >
+          {successMessage}
+        </Alert>
+      )}
+
+      <form
+        className="AdminModerationPage-blocklistForm"
+        onSubmit={handleSubmit}
+      >
+        <label className="AdminModerationPage-blocklistField">
+          <span className="ui-caption">Match type</span>
+          <select
+            className="AdminModerationPage-blocklistControl"
+            value={matchType}
+            onChange={(event) =>
+              setMatchType(event.target.value as "url" | "domain")
+            }
+          >
+            <option value="domain">Domain</option>
+            <option value="url">Exact URL</option>
+          </select>
+        </label>
+        <label className="AdminModerationPage-blocklistField">
+          <span className="ui-caption">
+            {matchType === "domain" ? "Domain" : "URL"}
+          </span>
+          <input
+            className="AdminModerationPage-blocklistControl"
+            type={matchType === "url" ? "url" : "text"}
+            value={value}
+            placeholder={
+              matchType === "domain"
+                ? "example.com"
+                : "https://example.com/path"
+            }
+            required
+            onChange={(event) => setValue(event.target.value)}
+          />
+        </label>
+        <Button
+          type="submit"
+          disabled={pendingEntryId !== null || !value.trim()}
+          isLoading={pendingEntryId === "new"}
+        >
+          Add rule
+        </Button>
+      </form>
+
+      {isLoading ? (
+        <p className="body-base">Loading blocklist rules…</p>
+      ) : entries.length === 0 ? (
+        <p className="body-base">No submission blocklist rules.</p>
+      ) : (
+        <ul className="AdminModerationPage-blocklistList">
+          {entries.map((entry) => (
+            <li className="AdminModerationPage-blocklistItem" key={entry.id}>
+              <div>
+                <strong>
+                  {entry.matchType === "domain" ? "Domain" : "Exact URL"}
+                </strong>
+                <span className="AdminModerationPage-blocklistValue">
+                  {entry.normalizedValue}
+                </span>
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={pendingEntryId !== null}
+                isLoading={pendingEntryId === entry.id}
+                onClick={() => void removeEntry(entry)}
+              >
+                Remove
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="AdminModerationPage-blocklistAudit">
+        <h3 className="heading-lg">Recent blocked attempts</h3>
+        {recentEvents.length === 0 ? (
+          <p className="body-base">No blocked attempts recorded.</p>
+        ) : (
+          <ul className="AdminModerationPage-blocklistList">
+            {recentEvents.map((event) => (
+              <li className="AdminModerationPage-blocklistItem" key={event.id}>
+                <div>
+                  <strong>{event.normalizedUrl}</strong>
+                  <span className="AdminModerationPage-blocklistValue">
+                    Matched {event.matchedType}: {event.matchedValue}
+                  </span>
+                </div>
+                <time className="ui-caption" dateTime={String(event.createdAt)}>
+                  {new Date(event.createdAt).toLocaleDateString()}
+                </time>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/SubmissionBlocklist.tsx
+++ b/src/components/admin/SubmissionBlocklist.tsx
@@ -1,15 +1,20 @@
 import type { FormEvent } from "react";
 
+import type { BlocklistMatchType } from "../../api/admin";
 import { useAdminBlocklist } from "../../hooks/useAdminBlocklist";
 import { Alert } from "../ui/Alert";
 import { Button } from "../ui/Button";
 
 interface SubmissionBlocklistProps {
   accessToken: string | null;
+  isAdmin: boolean;
 }
 
 /** Admin controls for listing, adding, and removing private submission rules. */
-export function SubmissionBlocklist({ accessToken }: SubmissionBlocklistProps) {
+export function SubmissionBlocklist({
+  accessToken,
+  isAdmin,
+}: SubmissionBlocklistProps) {
   const {
     addEntry,
     entries,
@@ -25,7 +30,7 @@ export function SubmissionBlocklist({ accessToken }: SubmissionBlocklistProps) {
     setValue,
     successMessage,
     value,
-  } = useAdminBlocklist({ accessToken, isAdmin: true });
+  } = useAdminBlocklist({ accessToken, isAdmin });
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -74,7 +79,7 @@ export function SubmissionBlocklist({ accessToken }: SubmissionBlocklistProps) {
             className="AdminModerationPage-blocklistControl"
             value={matchType}
             onChange={(event) =>
-              setMatchType(event.target.value as "url" | "domain")
+              setMatchType(event.target.value as BlocklistMatchType)
             }
           >
             <option value="domain">Domain</option>
@@ -128,6 +133,7 @@ export function SubmissionBlocklist({ accessToken }: SubmissionBlocklistProps) {
                 variant="secondary"
                 disabled={pendingEntryId !== null}
                 isLoading={pendingEntryId === entry.id}
+                aria-label={`Remove ${entry.matchType} rule ${entry.normalizedValue}`}
                 onClick={() => void removeEntry(entry)}
               >
                 Remove

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -334,6 +334,10 @@ export const publicSubmissionBlocklistTable = pgTable(
       "public_submission_blocklist_value_check",
       sql`length(btrim(${table.normalizedValue})) > 0`,
     ),
+    check(
+      "public_submission_blocklist_match_type_check",
+      sql`${table.matchType} in ('url', 'domain')`,
+    ),
   ],
 ).enableRLS();
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -308,6 +308,64 @@ export const publicSubmissionRateLimitsTable = pgTable(
   ],
 ).enableRLS();
 
+// Server-only moderation controls. Browser roles are explicitly revoked in the
+// migration so public clients cannot enumerate enforcement rules or audit data.
+export const publicSubmissionBlocklistTable = pgTable(
+  "public_submission_blocklist",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    matchType: text("match_type", { enum: ["url", "domain"] }).notNull(),
+    value: text("value").notNull(),
+    normalizedValue: text("normalized_value").notNull(),
+    createdBy: uuid("created_by").references(() => authUsersTable.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("unique_public_submission_blocklist_match").on(
+      table.matchType,
+      table.normalizedValue,
+    ),
+    index("idx_public_submission_blocklist_created_at").on(table.createdAt),
+    check(
+      "public_submission_blocklist_value_check",
+      sql`length(btrim(${table.normalizedValue})) > 0`,
+    ),
+  ],
+).enableRLS();
+
+export const publicSubmissionBlocklistEventsTable = pgTable(
+  "public_submission_blocklist_events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    blocklistEntryId: uuid("blocklist_entry_id").references(
+      () => publicSubmissionBlocklistTable.id,
+      { onDelete: "set null" },
+    ),
+    normalizedUrl: text("normalized_url").notNull(),
+    matchedType: text("matched_type", { enum: ["url", "domain"] }).notNull(),
+    matchedValue: text("matched_value").notNull(),
+    submittedByUserId: uuid("submitted_by_user_id").references(
+      () => authUsersTable.id,
+      { onDelete: "set null" },
+    ),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("idx_public_submission_blocklist_events_created_at").on(
+      table.createdAt,
+    ),
+    index("idx_public_submission_blocklist_events_entry").on(
+      table.blocklistEntryId,
+    ),
+  ],
+).enableRLS();
+
 export type InsertResource = typeof resourcesTable.$inferInsert;
 export type SelectResource = typeof resourcesTable.$inferSelect;
 export type InsertToolListing = typeof toolListingsTable.$inferInsert;

--- a/src/hooks/useAdminBlocklist.ts
+++ b/src/hooks/useAdminBlocklist.ts
@@ -1,0 +1,143 @@
+import { useEffect, useState, useTransition } from "react";
+
+import {
+  createSubmissionBlocklistRule,
+  deleteSubmissionBlocklistRule,
+  getSubmissionBlocklist,
+  type BlocklistEntry,
+  type BlocklistEvent,
+  type BlocklistMatchType,
+} from "../api/admin";
+
+interface UseAdminBlocklistOptions {
+  accessToken: string | null;
+  isAdmin: boolean;
+}
+
+/** Loads and mutates private blocklist rules for the admin moderation page. */
+export function useAdminBlocklist({
+  accessToken,
+  isAdmin,
+}: UseAdminBlocklistOptions) {
+  const [entries, setEntries] = useState<BlocklistEntry[]>([]);
+  const [recentEvents, setRecentEvents] = useState<BlocklistEvent[]>([]);
+  const [matchType, setMatchType] = useState<BlocklistMatchType>("domain");
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [pendingEntryId, setPendingEntryId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPendingTransition, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!accessToken || !isAdmin) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const blocklistAccessToken = accessToken;
+
+    async function loadBlocklist() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const blocklistState = await getSubmissionBlocklist(
+          blocklistAccessToken,
+          controller.signal,
+        );
+        if (!controller.signal.aborted) {
+          startTransition(() => {
+            setEntries(blocklistState.entries);
+            setRecentEvents(blocklistState.recentEvents);
+          });
+        }
+      } catch (loadError) {
+        if (!controller.signal.aborted) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "Could not load blocklist rules.",
+          );
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadBlocklist();
+
+    return () => controller.abort();
+  }, [accessToken, isAdmin]);
+
+  async function addEntry() {
+    if (!accessToken || !value.trim()) {
+      return;
+    }
+
+    setPendingEntryId("new");
+    setError(null);
+    setSuccessMessage(null);
+    try {
+      const entry = await createSubmissionBlocklistRule(accessToken, {
+        matchType,
+        value: value.trim(),
+      });
+      startTransition(() => setEntries((current) => [entry, ...current]));
+      setValue("");
+      setSuccessMessage("Blocklist rule added.");
+    } catch (addError) {
+      setError(
+        addError instanceof Error
+          ? addError.message
+          : "Could not add blocklist rule.",
+      );
+    } finally {
+      setPendingEntryId(null);
+    }
+  }
+
+  async function removeEntry(entry: BlocklistEntry) {
+    if (!accessToken) {
+      return;
+    }
+
+    setPendingEntryId(entry.id);
+    setError(null);
+    setSuccessMessage(null);
+    try {
+      await deleteSubmissionBlocklistRule(accessToken, entry.id);
+      startTransition(() => {
+        setEntries((current) => current.filter(({ id }) => id !== entry.id));
+      });
+      setSuccessMessage("Blocklist rule removed.");
+    } catch (removeError) {
+      setError(
+        removeError instanceof Error
+          ? removeError.message
+          : "Could not remove blocklist rule.",
+      );
+    } finally {
+      setPendingEntryId(null);
+    }
+  }
+
+  return {
+    addEntry,
+    entries,
+    error,
+    isLoading: isLoading || isPendingTransition,
+    matchType,
+    pendingEntryId,
+    recentEvents,
+    removeEntry,
+    setError,
+    setMatchType,
+    setSuccessMessage,
+    setValue,
+    successMessage,
+    value,
+  };
+}

--- a/src/pages/AdminModerationPage.css
+++ b/src/pages/AdminModerationPage.css
@@ -11,12 +11,80 @@
 .AdminModerationPage-card,
 .AdminModerationPage-cardBody,
 .AdminModerationPage-actions,
-.AdminModerationPage-reason {
+.AdminModerationPage-reason,
+.AdminModerationPage-blocklist,
+.AdminModerationPage-blocklistField {
   display: grid;
 }
 
 .AdminModerationPage-header {
   gap: var(--size-8);
+}
+
+.AdminModerationPage-blocklist {
+  background-color: var(--color-surface-raised);
+  border: var(--border-default);
+  border-radius: var(--radius-md);
+  gap: var(--size-16);
+  padding: var(--size-20);
+}
+
+.AdminModerationPage-blocklistHeader h2,
+.AdminModerationPage-blocklistHeader p {
+  margin: 0;
+}
+
+.AdminModerationPage-blocklistForm {
+  align-items: end;
+  display: grid;
+  gap: var(--size-12);
+}
+
+.AdminModerationPage-blocklistField {
+  gap: var(--size-4);
+}
+
+.AdminModerationPage-blocklistAudit {
+  border-block-start: var(--border-default);
+  padding-block-start: var(--size-16);
+}
+
+.AdminModerationPage-blocklistAudit h3,
+.AdminModerationPage-blocklistAudit p {
+  margin: 0;
+}
+
+.AdminModerationPage-blocklistControl {
+  background-color: var(--color-surface);
+  border: var(--border-strong);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font: inherit;
+  min-block-size: 2.75rem;
+  padding-block: var(--size-8);
+  padding-inline: var(--size-12);
+}
+
+.AdminModerationPage-blocklistList {
+  display: grid;
+  gap: var(--size-8);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.AdminModerationPage-blocklistItem {
+  align-items: center;
+  border-block-start: var(--border-default);
+  display: flex;
+  gap: var(--size-12);
+  justify-content: space-between;
+  padding-block-start: var(--size-12);
+}
+
+.AdminModerationPage-blocklistValue {
+  display: block;
+  overflow-wrap: anywhere;
 }
 
 .AdminModerationPage-title,
@@ -136,6 +204,10 @@
 }
 
 @media (width >= 48rem) {
+  .AdminModerationPage-blocklistForm {
+    grid-template-columns: minmax(8rem, 0.25fr) minmax(20rem, 1fr) auto;
+  }
+
   .AdminModerationPage-actions {
     align-items: end;
     grid-template-columns: minmax(20rem, 1fr) auto;

--- a/src/pages/AdminModerationPage.tsx
+++ b/src/pages/AdminModerationPage.tsx
@@ -1,5 +1,6 @@
 import { Alert } from "../components/ui/Alert";
 import { Button } from "../components/ui/Button";
+import { SubmissionBlocklist } from "../components/admin/SubmissionBlocklist";
 import {
   moderationTypeLabels,
   moderationTypes,
@@ -71,6 +72,8 @@ export function AdminModerationPage() {
           Review pending tools, resources, stacks, and stack items.
         </p>
       </header>
+
+      <SubmissionBlocklist accessToken={accessToken} />
 
       <div
         className="AdminModerationPage-tabs"

--- a/src/pages/AdminModerationPage.tsx
+++ b/src/pages/AdminModerationPage.tsx
@@ -73,7 +73,7 @@ export function AdminModerationPage() {
         </p>
       </header>
 
-      <SubmissionBlocklist accessToken={accessToken} />
+      <SubmissionBlocklist accessToken={accessToken} isAdmin={isAdmin} />
 
       <div
         className="AdminModerationPage-tabs"


### PR DESCRIPTION
Closes #119

## What changed

- add server-only URL/domain blocklist and audit tables with RLS and browser-role revocations
- normalize exact URL and parent-domain rules, including common `www` variants and subdomains
- enforce rules before DNS, metadata extraction, screenshots, or moderation-record creation
- return a generic public rejection while recording a redacted internal audit event
- add an admin-only CRUD API and moderation-page controls for rules and recent blocked attempts
- add function, API, normalization, security-migration, and rejection-path coverage

## Why

Public submissions need a server-authoritative way to stop known abusive URLs and domains before they create moderation load or trigger external metadata work. The public response intentionally does not reveal the matching rule.

## Deployment note

Apply `migrations/postgres/0010_lame_rage.sql` before deploying code that uses the new tables. The migration includes the required Drizzle journal/snapshot state.

## Validation

- `pnpm test`
- `pnpm lint` (passes with the existing generated `public/mockServiceWorker.js` warning)
- `pnpm lint:css`
- `pnpm typecheck`
- `pnpm run build`
- `npx playwright test --project=chromium`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin submission blocklist for domains and exact URLs, with an admin UI to add and remove rules.
  * Added a “recent blocked attempts” audit view for administrators.
  * Blocklisted submissions are now rejected immediately, with audit records showing redacted matched details.
* **Bug Fixes**
  * Improved rule validation and handling of duplicate/invalid entries.
  * Fail-closed behavior returns a generic error when the blocklist datastore is unavailable.
* **Tests**
  * Added end-to-end coverage for authorization, enforcement, validation, and database security controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->