### PR TITLE
Add library URL inspection and metadata overrides

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -36,3 +36,11 @@ SUBMISSION_RATE_LIMIT_SECRET=
 SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS=5
 # @required
 SUBMISSION_RATE_LIMIT_WINDOW_SECONDS=3600
+
+# Interactive library inspection rate limiting (server-only)
+# @type=string(isLength=64,matches=/^[0-9A-Fa-f]{64}$/) @sensitive
+INSPECTION_RATE_LIMIT_SECRET=
+# @required
+INSPECTION_RATE_LIMIT_MAX_ATTEMPTS=30
+# @required
+INSPECTION_RATE_LIMIT_WINDOW_SECONDS=600

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,5 +163,7 @@ Async hooks that use request IDs for stale-response protection must invalidate e
 
 - JSDoc on functions/classes — concise, clear
 - Search codebase before new components/styles; reuse tokens and patterns
-- Move repeated validation/error aggregation into shared helpers instead of copying function-local implementations
+- Before adding a function, search for equivalent behavior and extend or parameterize an existing utility when the abstraction remains cohesive.
+- Do not duplicate orchestration, validation, parsing, or error aggregation across features. Extract shared, well-tested utilities and keep feature-specific differences explicit through typed configuration.
+- Test shared utilities at their behavioral boundaries and retain focused call-site tests that prove each consumer supplies the correct configuration.
 - Barrel files (`index.ts` re-exports): curated public API only, not every directory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,20 @@ gh issue close <id>   # Complete work
 
 GitHub Issues is the source of truth. See [`ROADMAP.md`](./ROADMAP.md) for milestone context.
 
+## Git workflow
+
+- Before editing, run `git status -sb` and confirm the current branch.
+- Never implement directly on `main`; create or switch to an issue branch first.
+- If work was accidentally started on `main`, create the issue branch immediately and preserve the working tree—do not discard or rewrite changes.
+- Before committing, review the complete diff and stage only files in the requested scope.
+
+## Review feedback
+
+- Verify every finding against the current code before changing it.
+- Fix only findings that still apply; briefly document skipped or inapplicable feedback.
+- Keep review fixes minimal and preserve established behavior unless the finding requires a behavior change.
+- Validate focused coverage for each accepted finding, then run the project-level checks.
+
 ## Collaboration
 
 **Partnership, not order-taking.** Push back when a request contradicts established patterns or adds complexity without clear benefit.
@@ -46,6 +60,14 @@ Consult current docs (Context7 MCP or official URLs) before implementing. Do not
 
 Details: [`architecture.md`](./architecture.md) · [Browserless screenshot API](https://docs.browserless.io/rest-apis/screenshot-api) · [Supabase docs](https://supabase.com/docs)
 
+### Server-side URL fetching
+
+- Treat every user-controlled server-side URL fetch as SSRF-sensitive, including redirects and metadata/image fetches.
+- URL validation before `fetch()` is insufficient: resolve with a bounded timeout, reject non-public addresses, and revalidate/pin DNS in the connection path so rebinding cannot change the destination.
+- Reuse the shared public-URL resolver and pass its dispatcher through the fetch path; close request-scoped dispatchers after the response is consumed.
+- Rate-limit authenticated endpoints before they perform DNS lookup, screenshots, metadata extraction, or other external work. Keep rate-limit keys scoped so one feature cannot exhaust another feature's quota.
+- Fail closed on DNS timeout, lookup failure, mixed public/private answers, or connection-time revalidation failure.
+
 ## Database migrations (Supabase Postgres)
 
 **Schema must reach production before code that depends on new columns.**
@@ -70,6 +92,8 @@ Env: `.env.schema` (Varlock). Local setup: [`docs/local-development.md`](./docs/
 ## Validation and API patterns
 
 **Valibot only** — no hand-rolled validation. Schemas live in `src/lib/validation.ts`; infer types with `v.InferOutput`.
+
+Persisted user-controlled strings must have explicit maximum lengths in their Valibot schemas, including optional override fields.
 
 | Use Valibot                      | Use plain TS types    |
 | -------------------------------- | --------------------- |
@@ -131,10 +155,13 @@ React 19 · Vite SPA (not Next.js RSC). React Compiler enabled — avoid manual 
 
 **React 19:** prefer Actions/`useActionState` for forms, `use()` where appropriate, refs as regular props (no `forwardRef`). Skip Server Components guidance — not applicable here.
 
+Async hooks that use request IDs for stale-response protection must invalidate every relevant request ID during effect cleanup so unmounts and dependency changes cannot update stale state.
+
 **Naming:** no single-letter variables except `a`/`b` in sort comparators.
 
 ## Code style
 
 - JSDoc on functions/classes — concise, clear
 - Search codebase before new components/styles; reuse tokens and patterns
+- Move repeated validation/error aggregation into shared helpers instead of copying function-local implementations
 - Barrel files (`index.ts` re-exports): curated public API only, not every directory

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Required for full local functionality:
 - `SUBMISSION_RATE_LIMIT_SECRET` — server-only 64-character hexadecimal HMAC secret
 - `SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS`
 - `SUBMISSION_RATE_LIMIT_WINDOW_SECONDS`
+- `INSPECTION_RATE_LIMIT_SECRET` — separate server-only 64-character hexadecimal HMAC secret
+- `INSPECTION_RATE_LIMIT_MAX_ATTEMPTS`
+- `INSPECTION_RATE_LIMIT_WINDOW_SECONDS`
 - `SENTRY_DSN` (optional)
 
 Package manager note: this repository pins pnpm via `packageManager` in `package.json` so Netlify Corepack resolves the exact pnpm version during builds.

--- a/architecture.md
+++ b/architecture.md
@@ -558,6 +558,9 @@ environment settings. Key variables:
 | `SUBMISSION_RATE_LIMIT_SECRET`         | Server only     | 64-character hexadecimal HMAC key            |
 | `SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS`   | Server only     | Attempts permitted in one fixed window       |
 | `SUBMISSION_RATE_LIMIT_WINDOW_SECONDS` | Server only     | Fixed-window duration in seconds             |
+| `INSPECTION_RATE_LIMIT_SECRET`         | Server only     | Separate 64-character hexadecimal HMAC key   |
+| `INSPECTION_RATE_LIMIT_MAX_ATTEMPTS`   | Server only     | Interactive previews permitted per window    |
+| `INSPECTION_RATE_LIMIT_WINDOW_SECONDS` | Server only     | Preview fixed-window duration in seconds     |
 | `SENTRY_DSN`                           | Server only     | Optional error tracking                      |
 
 Server-side functions read secrets via `Netlify.env.get()`. Client-visible vars use the `VITE_` prefix and are bundled by Vite.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -49,6 +49,9 @@ The required names are:
 - `SUBMISSION_RATE_LIMIT_SECRET` - a server-only secret of exactly 64 hexadecimal characters
 - `SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS` - positive integer, at most 1000
 - `SUBMISSION_RATE_LIMIT_WINDOW_SECONDS` - positive integer, at most 86400
+- `INSPECTION_RATE_LIMIT_SECRET` - a separate server-only secret of exactly 64 hexadecimal characters
+- `INSPECTION_RATE_LIMIT_MAX_ATTEMPTS` - positive integer, at most 1000
+- `INSPECTION_RATE_LIMIT_WINDOW_SECONDS` - positive integer, at most 86400
 
 `SENTRY_DSN` is a separate optional setting read by the Functions when
 configured; it is not required by `.env.schema`. The `VITE_` variables are
@@ -57,9 +60,11 @@ server-side values. `.env.schema` declares `SUBMISSION_RATE_LIMIT_SECRET` with
 an intentionally blank value and `@sensitive`. This keeps frontend-only builds
 independent of the server runtime secret while providing no checked-in default.
 Export it from a secure external process environment or configure a secure
-Varlock source before exercising submissions. The Netlify Function requires it
-at runtime and fails closed when it is absent, is not exactly 64 characters,
-or contains non-hexadecimal characters. Generate a suitable value with
+Varlock source before exercising submissions. Configure
+`INSPECTION_RATE_LIMIT_SECRET` the same way before exercising library metadata
+previews. The Netlify Functions require these secrets at runtime and fail
+closed when one is absent, is not exactly 64 characters, or contains
+non-hexadecimal characters. Generate suitable values with
 `openssl rand -hex 32`.
 
 ## 3. Apply Supabase migrations

--- a/netlify/functions/__tests__/add-library.test.ts
+++ b/netlify/functions/__tests__/add-library.test.ts
@@ -93,6 +93,90 @@ describe("add-library", () => {
     expect(mockDb.values).toHaveBeenCalledWith({
       userId: "user-1",
       resourceId: "resource-1",
+      titleOverride: null,
+      descriptionOverride: null,
+      notes: "",
+      tags: ["react"],
+    });
+  });
+
+  it("persists edited metadata as personal bookmark overrides", async () => {
+    const mockDb = createMockDb();
+    mockDb.limit
+      .mockResolvedValueOnce([
+        {
+          id: "resource-1",
+          pageTitle: "Shared title",
+          metaDescription: "Shared description",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mockDb.returning.mockResolvedValueOnce([{ id: "bookmark-1" }]);
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+
+    const res = await addLibrary(
+      new Request("https://test.com/api/library", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url: "https://example.com/resource",
+          title: "  Personal title  ",
+          description: "Personal description",
+          tags: ["React"],
+        }),
+      }),
+      createMockContext(),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockDb.values).toHaveBeenCalledWith({
+      userId: "user-1",
+      resourceId: "resource-1",
+      titleOverride: "Personal title",
+      descriptionOverride: "Personal description",
+      notes: "",
+      tags: ["react"],
+    });
+  });
+
+  it("stores null overrides for unchanged or empty metadata", async () => {
+    const mockDb = createMockDb();
+    mockDb.limit
+      .mockResolvedValueOnce([
+        {
+          id: "resource-1",
+          pageTitle: "Shared title",
+          metaDescription: "Shared description",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mockDb.returning.mockResolvedValueOnce([{ id: "bookmark-1" }]);
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+
+    const res = await addLibrary(
+      new Request("https://test.com/api/library", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url: "https://example.com/resource",
+          title: "Shared title",
+          description: "  ",
+          tags: ["React"],
+        }),
+      }),
+      createMockContext(),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockDb.values).toHaveBeenCalledWith({
+      userId: "user-1",
+      resourceId: "resource-1",
+      titleOverride: null,
+      descriptionOverride: null,
       notes: "",
       tags: ["react"],
     });

--- a/netlify/functions/__tests__/add-library.test.ts
+++ b/netlify/functions/__tests__/add-library.test.ts
@@ -181,4 +181,42 @@ describe("add-library", () => {
       tags: ["react"],
     });
   });
+
+  it("saves a private library URL without fetching metadata server-side", async () => {
+    const mockDb = createMockDb();
+    mockDb.limit.mockResolvedValueOnce([]);
+    mockDb.returning
+      .mockResolvedValueOnce([
+        {
+          id: "resource-1",
+          pageTitle: "http://127.0.0.1/resource",
+          metaDescription: "",
+        },
+      ])
+      .mockResolvedValueOnce([{ id: "bookmark-1" }]);
+    vi.mocked(getDb).mockReturnValue(
+      mockDb as unknown as ReturnType<typeof getDb>,
+    );
+
+    const response = await addLibrary(
+      new Request("https://test.com/api/library", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url: "http://127.0.0.1/resource",
+          tags: ["private"],
+        }),
+      }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(201);
+    expect(extractMetadata).not.toHaveBeenCalled();
+    expect(mockDb.values).toHaveBeenNthCalledWith(1, {
+      normalizedUrl: "http://127.0.0.1/resource",
+      canonicalUrl: "http://127.0.0.1/resource",
+      pageTitle: "http://127.0.0.1/resource",
+      metaDescription: "",
+    });
+  });
 });

--- a/netlify/functions/__tests__/inspect-library.test.ts
+++ b/netlify/functions/__tests__/inspect-library.test.ts
@@ -11,7 +11,7 @@ vi.mock("../lib/sentry", () => ({
 }));
 
 vi.mock("../lib/submission-rate-limit", () => ({
-  getSubmissionRateLimitConfig: vi.fn(),
+  getInspectionRateLimitConfig: vi.fn(),
   createSubmissionRateLimitKey: vi.fn(),
   consumeSubmissionRateLimit: vi.fn(),
 }));
@@ -30,7 +30,7 @@ import { captureError, flushSentry } from "../lib/sentry";
 import {
   consumeSubmissionRateLimit,
   createSubmissionRateLimitKey,
-  getSubmissionRateLimitConfig,
+  getInspectionRateLimitConfig,
 } from "../lib/submission-rate-limit";
 import { lookup } from "node:dns/promises";
 import { extractMetadata } from "../../../src/lib/services/metadata";
@@ -57,10 +57,10 @@ describe("inspect-library", () => {
     vi.mocked(lookup).mockResolvedValue([
       { address: "93.184.216.34", family: 4 },
     ] as never);
-    vi.mocked(getSubmissionRateLimitConfig).mockReturnValue({
+    vi.mocked(getInspectionRateLimitConfig).mockReturnValue({
       secret: "a".repeat(64),
-      maxAttempts: 5,
-      windowSeconds: 3600,
+      maxAttempts: 30,
+      windowSeconds: 600,
     });
     vi.mocked(createSubmissionRateLimitKey).mockReturnValue("inspection-key");
     vi.mocked(consumeSubmissionRateLimit).mockResolvedValue(true);
@@ -185,6 +185,11 @@ describe("inspect-library", () => {
       "a".repeat(64),
       "library-inspection",
     );
+    expect(consumeSubmissionRateLimit).toHaveBeenCalledWith("inspection-key", {
+      secret: "a".repeat(64),
+      maxAttempts: 30,
+      windowSeconds: 600,
+    });
     expect(lookup).not.toHaveBeenCalled();
     expect(extractMetadata).not.toHaveBeenCalled();
   });

--- a/netlify/functions/__tests__/inspect-library.test.ts
+++ b/netlify/functions/__tests__/inspect-library.test.ts
@@ -10,6 +10,12 @@ vi.mock("../lib/sentry", () => ({
   flushSentry: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../lib/submission-rate-limit", () => ({
+  getSubmissionRateLimitConfig: vi.fn(),
+  createSubmissionRateLimitKey: vi.fn(),
+  consumeSubmissionRateLimit: vi.fn(),
+}));
+
 vi.mock("../../../src/lib/services/metadata", () => ({
   extractMetadata: vi.fn(),
 }));
@@ -21,6 +27,11 @@ vi.mock("node:dns/promises", () => ({
 import inspectLibrary from "../inspect-library.mts";
 import { verifyAuthenticatedUser } from "../lib/auth";
 import { captureError, flushSentry } from "../lib/sentry";
+import {
+  consumeSubmissionRateLimit,
+  createSubmissionRateLimitKey,
+  getSubmissionRateLimitConfig,
+} from "../lib/submission-rate-limit";
 import { lookup } from "node:dns/promises";
 import { extractMetadata } from "../../../src/lib/services/metadata";
 import { createMockContext } from "./test-utils";
@@ -46,6 +57,13 @@ describe("inspect-library", () => {
     vi.mocked(lookup).mockResolvedValue([
       { address: "93.184.216.34", family: 4 },
     ] as never);
+    vi.mocked(getSubmissionRateLimitConfig).mockReturnValue({
+      secret: "a".repeat(64),
+      maxAttempts: 5,
+      windowSeconds: 3600,
+    });
+    vi.mocked(createSubmissionRateLimitKey).mockReturnValue("inspection-key");
+    vi.mocked(consumeSubmissionRateLimit).mockResolvedValue(true);
   });
 
   it("returns extracted title and description", async () => {
@@ -70,6 +88,7 @@ describe("inspect-library", () => {
     });
     expect(extractMetadata).toHaveBeenCalledWith(
       "https://example.com/resource",
+      { dispatcher: expect.anything() },
     );
   });
 
@@ -144,6 +163,29 @@ describe("inspect-library", () => {
     );
 
     expect(response.status).toBe(401);
+    expect(consumeSubmissionRateLimit).not.toHaveBeenCalled();
+    expect(extractMetadata).not.toHaveBeenCalled();
+  });
+
+  it("rate limits the authenticated user before DNS or metadata work", async () => {
+    vi.mocked(consumeSubmissionRateLimit).mockResolvedValue(false);
+
+    const response = await inspectLibrary(
+      createInspectionRequest({ url: "https://example.com/resource" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(429);
+    expect(createSubmissionRateLimitKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authenticated: expect.objectContaining({
+          user: expect.objectContaining({ id: "user-1" }),
+        }),
+      }),
+      "a".repeat(64),
+      "library-inspection",
+    );
+    expect(lookup).not.toHaveBeenCalled();
     expect(extractMetadata).not.toHaveBeenCalled();
   });
 

--- a/netlify/functions/__tests__/inspect-library.test.ts
+++ b/netlify/functions/__tests__/inspect-library.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth", () => ({
+  verifyAuthenticatedUser: vi.fn(),
+}));
+
+vi.mock("../lib/sentry", () => ({
+  initSentry: vi.fn(),
+  captureError: vi.fn(),
+  flushSentry: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/lib/services/metadata", () => ({
+  extractMetadata: vi.fn(),
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
+}));
+
+import inspectLibrary from "../inspect-library.mts";
+import { verifyAuthenticatedUser } from "../lib/auth";
+import { captureError, flushSentry } from "../lib/sentry";
+import { lookup } from "node:dns/promises";
+import { extractMetadata } from "../../../src/lib/services/metadata";
+import { createMockContext } from "./test-utils";
+
+function createInspectionRequest(body: unknown): Request {
+  return new Request("https://test.com/api/library/inspect", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer test-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("inspect-library", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(verifyAuthenticatedUser).mockResolvedValue({
+      user: { id: "user-1" },
+      isAdmin: false,
+    } as never);
+    vi.mocked(lookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+    ] as never);
+  });
+
+  it("returns extracted title and description", async () => {
+    vi.mocked(extractMetadata).mockResolvedValue({
+      title: "Example title",
+      description: "Example description",
+      ogImage: null,
+    });
+
+    const response = await inspectLibrary(
+      createInspectionRequest({ url: "https://example.com/resource" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      data: {
+        title: "Example title",
+        description: "Example description",
+      },
+    });
+    expect(extractMetadata).toHaveBeenCalledWith(
+      "https://example.com/resource",
+    );
+  });
+
+  it("returns a nonblocking inspection error and records a sanitized extraction failure", async () => {
+    vi.mocked(extractMetadata).mockResolvedValue({
+      title: null,
+      description: null,
+      ogImage: null,
+      error: "request included sensitive upstream detail",
+    });
+
+    const response = await inspectLibrary(
+      createInspectionRequest({ url: "https://example.com/private-path" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      success: false,
+      error:
+        "We couldn't inspect this URL right now. You can still save it to your library.",
+    });
+    expect(captureError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Library metadata inspection failed",
+      }),
+      {
+        function: "inspect-library",
+        dependency: "metadata-extractor",
+      },
+    );
+    expect(JSON.stringify(vi.mocked(captureError).mock.calls)).not.toContain(
+      "private-path",
+    );
+    expect(JSON.stringify(vi.mocked(captureError).mock.calls)).not.toContain(
+      "sensitive upstream detail",
+    );
+    expect(flushSentry).toHaveBeenCalledOnce();
+  });
+
+  it("returns the same sanitized inspection error when extraction throws", async () => {
+    vi.mocked(extractMetadata).mockRejectedValue(
+      new Error("sensitive thrown detail"),
+    );
+
+    const response = await inspectLibrary(
+      createInspectionRequest({ url: "https://example.com/private-path" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      success: false,
+      error:
+        "We couldn't inspect this URL right now. You can still save it to your library.",
+    });
+    expect(JSON.stringify(vi.mocked(captureError).mock.calls)).not.toContain(
+      "private-path",
+    );
+    expect(JSON.stringify(vi.mocked(captureError).mock.calls)).not.toContain(
+      "sensitive thrown detail",
+    );
+    expect(flushSentry).toHaveBeenCalledOnce();
+  });
+
+  it("requires authentication", async () => {
+    vi.mocked(verifyAuthenticatedUser).mockResolvedValue(null);
+
+    const response = await inspectLibrary(
+      createInspectionRequest({ url: "https://example.com/resource" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(401);
+    expect(extractMetadata).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid URLs before metadata extraction", async () => {
+    const response = await inspectLibrary(
+      createInspectionRequest({ url: "not-a-url" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(422);
+    expect(extractMetadata).not.toHaveBeenCalled();
+  });
+
+  it("rejects private URLs before DNS or metadata extraction", async () => {
+    const response = await inspectLibrary(
+      createInspectionRequest({ url: "http://127.0.0.1/admin" }),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Validation failed",
+      details: {
+        url: ["Please enter a publicly reachable HTTP/HTTPS URL"],
+      },
+    });
+    expect(lookup).not.toHaveBeenCalled();
+    expect(extractMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/netlify/functions/__tests__/process-tool.test.ts
+++ b/netlify/functions/__tests__/process-tool.test.ts
@@ -478,7 +478,9 @@ describe("process-tool", () => {
 
       await processTool(req, mockContext);
 
-      expect(extractMetadata).toHaveBeenCalledWith("https://example.com/tool");
+      expect(extractMetadata).toHaveBeenCalledWith("https://example.com/tool", {
+        dispatcher: expect.anything(),
+      });
     });
 
     it("uses OG image when available", async () => {

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -447,6 +447,8 @@ describe("public-submissions", () => {
         type: "resource",
         url: "https://example.com/internal",
         tags: ["security"],
+        submitterName: "Ada",
+        submitterGithubUsername: "ada",
       }),
       createMockContext(),
     );

--- a/netlify/functions/add-library.mts
+++ b/netlify/functions/add-library.mts
@@ -24,12 +24,17 @@ import { validatePersonalResourceRequest } from "../../src/lib/validation";
 function getIssueField(issue: BaseIssue<unknown>): string {
   const path = issue.path
     ?.map((pathItem) => pathItem.key)
-    .filter((key): key is string | number => typeof key === "string" || typeof key === "number");
+    .filter(
+      (key): key is string | number =>
+        typeof key === "string" || typeof key === "number",
+    );
 
   return path && path.length > 0 ? path.join(".") : "form";
 }
 
-function getValidationDetails(issues: readonly BaseIssue<unknown>[]): Record<string, string[]> {
+function getValidationDetails(
+  issues: readonly BaseIssue<unknown>[],
+): Record<string, string[]> {
   return issues.reduce<Record<string, string[]>>((details, issue) => {
     const field = getIssueField(issue);
     details[field] ??= [];
@@ -38,13 +43,30 @@ function getValidationDetails(issues: readonly BaseIssue<unknown>[]): Record<str
   }, {});
 }
 
+/** Returns a personal override only when it differs from shared metadata. */
+function getMetadataOverride(
+  submittedValue: string | undefined,
+  sharedValue: string,
+): string | null {
+  const normalizedValue = submittedValue?.trim();
+  if (!normalizedValue || normalizedValue === sharedValue) {
+    return null;
+  }
+
+  return normalizedValue;
+}
+
 export default async (req: Request, _context: Context) => {
   if (req.method !== "POST") {
     return methodNotAllowed(["POST"]);
   }
 
   try {
-    assertRequiredEnv(["SUPABASE_DATABASE_URL", "VITE_SUPABASE_URL", "VITE_SUPABASE_ANON_KEY"]);
+    assertRequiredEnv([
+      "SUPABASE_DATABASE_URL",
+      "VITE_SUPABASE_URL",
+      "VITE_SUPABASE_ANON_KEY",
+    ]);
   } catch (error) {
     return handleMissingEnvironmentError(error, "add-library");
   }
@@ -63,7 +85,10 @@ export default async (req: Request, _context: Context) => {
 
   const validation = validatePersonalResourceRequest(body);
   if (!validation.success) {
-    return validationError("Validation failed", getValidationDetails(validation.issues));
+    return validationError(
+      "Validation failed",
+      getValidationDetails(validation.issues),
+    );
   }
 
   const normalizedUrl = parseAndNormalizeUrl(validation.output.url);
@@ -73,17 +98,25 @@ export default async (req: Request, _context: Context) => {
     });
   }
 
-  const tags = [...new Set(validation.output.tags.map((tag) => tag.trim().toLowerCase()))];
+  const tags = [
+    ...new Set(validation.output.tags.map((tag) => tag.trim().toLowerCase())),
+  ];
 
   try {
     const db = getDb();
     const [existingResource] = await db
-      .select({ id: resourcesTable.id })
+      .select({
+        id: resourcesTable.id,
+        pageTitle: resourcesTable.pageTitle,
+        metaDescription: resourcesTable.metaDescription,
+      })
       .from(resourcesTable)
       .where(eq(resourcesTable.normalizedUrl, normalizedUrl))
       .limit(1);
 
     let resourceId = existingResource?.id;
+    let sharedTitle = existingResource?.pageTitle;
+    let sharedDescription = existingResource?.metaDescription;
 
     if (resourceId) {
       const [existingBookmark] = await db
@@ -102,21 +135,29 @@ export default async (req: Request, _context: Context) => {
       }
     } else {
       const metadata = await extractMetadata(normalizedUrl);
+      sharedTitle = metadata.title || normalizedUrl;
+      sharedDescription = metadata.description || "";
       const [resource] = await db
         .insert(resourcesTable)
         .values({
           normalizedUrl,
           canonicalUrl: normalizeUrl(validation.output.url),
-          pageTitle: metadata.title || normalizedUrl,
-          metaDescription: metadata.description || "",
+          pageTitle: sharedTitle,
+          metaDescription: sharedDescription,
         })
         .onConflictDoUpdate({
           target: resourcesTable.normalizedUrl,
           set: { normalizedUrl },
         })
-        .returning({ id: resourcesTable.id });
+        .returning({
+          id: resourcesTable.id,
+          pageTitle: resourcesTable.pageTitle,
+          metaDescription: resourcesTable.metaDescription,
+        });
 
       resourceId = resource.id;
+      sharedTitle = resource.pageTitle ?? sharedTitle;
+      sharedDescription = resource.metaDescription ?? sharedDescription;
     }
 
     const [bookmark] = await db
@@ -124,6 +165,14 @@ export default async (req: Request, _context: Context) => {
       .values({
         userId: authenticated.user.id,
         resourceId,
+        titleOverride: getMetadataOverride(
+          validation.output.title,
+          sharedTitle ?? normalizedUrl,
+        ),
+        descriptionOverride: getMetadataOverride(
+          validation.output.description,
+          sharedDescription ?? "",
+        ),
         notes: validation.output.notes ?? "",
         tags,
       })

--- a/netlify/functions/add-library.mts
+++ b/netlify/functions/add-library.mts
@@ -1,5 +1,4 @@
 import type { Config, Context } from "@netlify/functions";
-import type { BaseIssue } from "valibot";
 import { and, eq } from "drizzle-orm";
 
 import {
@@ -18,30 +17,10 @@ import {
   validationError,
   verifyAuthenticatedUser,
 } from "./lib";
+import { resolvePublicHttpUrl } from "./lib/public-url";
+import { getValidationDetails } from "./lib/validation";
 import { extractMetadata } from "../../src/lib/services/metadata";
 import { validatePersonalResourceRequest } from "../../src/lib/validation";
-
-function getIssueField(issue: BaseIssue<unknown>): string {
-  const path = issue.path
-    ?.map((pathItem) => pathItem.key)
-    .filter(
-      (key): key is string | number =>
-        typeof key === "string" || typeof key === "number",
-    );
-
-  return path && path.length > 0 ? path.join(".") : "form";
-}
-
-function getValidationDetails(
-  issues: readonly BaseIssue<unknown>[],
-): Record<string, string[]> {
-  return issues.reduce<Record<string, string[]>>((details, issue) => {
-    const field = getIssueField(issue);
-    details[field] ??= [];
-    details[field].push(issue.message);
-    return details;
-  }, {});
-}
 
 /** Returns a personal override only when it differs from shared metadata. */
 function getMetadataOverride(
@@ -134,9 +113,14 @@ export default async (req: Request, _context: Context) => {
         return conflict("This resource is already in your library");
       }
     } else {
-      const metadata = await extractMetadata(normalizedUrl);
-      sharedTitle = metadata.title || normalizedUrl;
-      sharedDescription = metadata.description || "";
+      const publicTarget = await resolvePublicHttpUrl(normalizedUrl);
+      const metadata = publicTarget
+        ? await extractMetadata(publicTarget.url, {
+            dispatcher: publicTarget.dispatcher,
+          }).finally(() => publicTarget.dispatcher.close())
+        : null;
+      sharedTitle = metadata?.title || normalizedUrl;
+      sharedDescription = metadata?.description || "";
       const [resource] = await db
         .insert(resourcesTable)
         .values({

--- a/netlify/functions/admin-blocklist.mts
+++ b/netlify/functions/admin-blocklist.mts
@@ -1,5 +1,4 @@
 import type { Config, Context } from "@netlify/functions";
-import type { BaseIssue } from "valibot";
 import * as v from "valibot";
 
 import {
@@ -17,6 +16,7 @@ import {
   validationError,
 } from "./lib";
 import { verifyAuthenticatedUser } from "./lib/auth";
+import { getValidationDetails } from "./lib/validation";
 import {
   blocklistDeleteRequestSchema,
   blocklistEntryRequestSchema,
@@ -25,15 +25,6 @@ import {
   listSubmissionBlocklistEntries,
   listSubmissionBlocklistEvents,
 } from "./lib/submission-blocklist";
-
-function getValidationDetails(issues: readonly BaseIssue<unknown>[]) {
-  return issues.reduce<Record<string, string[]>>((details, issue) => {
-    const field = issue.path?.map((item) => item.key).join(".") || "form";
-    details[field] ??= [];
-    details[field].push(issue.message);
-    return details;
-  }, {});
-}
 
 async function parseRequest(req: Request): Promise<unknown | Response> {
   try {

--- a/netlify/functions/admin-moderation.mts
+++ b/netlify/functions/admin-moderation.mts
@@ -1,5 +1,4 @@
 import type { Config, Context } from "@netlify/functions";
-import type { BaseIssue } from "valibot";
 import * as v from "valibot";
 
 import {
@@ -21,28 +20,7 @@ import {
   type ModerationEntityType,
 } from "./lib/admin-moderation";
 import { verifyAuthenticatedUser } from "./lib/auth";
-
-function getIssueField(issue: BaseIssue<unknown>): string {
-  const path = issue.path
-    ?.map((pathItem) => pathItem.key)
-    .filter(
-      (key): key is string | number =>
-        typeof key === "string" || typeof key === "number",
-    );
-
-  return path && path.length > 0 ? path.join(".") : "form";
-}
-
-function getValidationDetails(
-  issues: readonly BaseIssue<unknown>[],
-): Record<string, string[]> {
-  return issues.reduce<Record<string, string[]>>((details, issue) => {
-    const field = getIssueField(issue);
-    details[field] ??= [];
-    details[field].push(issue.message);
-    return details;
-  }, {});
-}
+import { getValidationDetails } from "./lib/validation";
 
 function parseTypeFilter(req: Request): ModerationEntityType | null | Response {
   const typeParam = new URL(req.url).searchParams.get("type");

--- a/netlify/functions/inspect-library.mts
+++ b/netlify/functions/inspect-library.mts
@@ -7,7 +7,7 @@ import {
   createSubmissionRateLimitKey,
   dependencyUnavailable,
   flushSentry,
-  getSubmissionRateLimitConfig,
+  getInspectionRateLimitConfig,
   handleMissingEnvironmentError,
   initSentry,
   methodNotAllowed,
@@ -63,7 +63,7 @@ export default async (req: Request, _context: Context) => {
   let rateLimitConfig: SubmissionRateLimitConfig;
   let keyHash: string;
   try {
-    rateLimitConfig = getSubmissionRateLimitConfig();
+    rateLimitConfig = getInspectionRateLimitConfig();
     keyHash = createSubmissionRateLimitKey(
       { authenticated, clientIp: undefined },
       rateLimitConfig.secret,

--- a/netlify/functions/inspect-library.mts
+++ b/netlify/functions/inspect-library.mts
@@ -1,0 +1,120 @@
+import type { Config, Context } from "@netlify/functions";
+import type { BaseIssue } from "valibot";
+
+import {
+  assertRequiredEnv,
+  captureError,
+  flushSentry,
+  handleMissingEnvironmentError,
+  initSentry,
+  methodNotAllowed,
+  ok,
+  serviceUnavailable,
+  unauthorized,
+  validationError,
+  verifyAuthenticatedUser,
+} from "./lib";
+import { resolvePublicHttpUrl } from "./lib/public-url";
+import { extractMetadata } from "../../src/lib/services/metadata";
+import { validateLibraryInspectionRequest } from "../../src/lib/validation";
+
+const PUBLIC_URL_ERROR = "Please enter a publicly reachable HTTP/HTTPS URL";
+const INSPECTION_ERROR =
+  "We couldn't inspect this URL right now. You can still save it to your library.";
+
+function getIssueField(issue: BaseIssue<unknown>): string {
+  const path = issue.path
+    ?.map((pathItem) => pathItem.key)
+    .filter(
+      (key): key is string | number =>
+        typeof key === "string" || typeof key === "number",
+    );
+
+  return path && path.length > 0 ? path.join(".") : "form";
+}
+
+function getValidationDetails(
+  issues: readonly BaseIssue<unknown>[],
+): Record<string, string[]> {
+  return issues.reduce<Record<string, string[]>>((details, issue) => {
+    const field = getIssueField(issue);
+    details[field] ??= [];
+    details[field].push(issue.message);
+    return details;
+  }, {});
+}
+
+/** Records inspection failures without including request or user data. */
+async function recordInspectionFailure(): Promise<void> {
+  captureError(new Error("Library metadata inspection failed"), {
+    function: "inspect-library",
+    dependency: "metadata-extractor",
+  });
+  await flushSentry();
+}
+
+export default async (req: Request, _context: Context) => {
+  initSentry();
+
+  if (req.method !== "POST") {
+    return methodNotAllowed(["POST"]);
+  }
+
+  try {
+    assertRequiredEnv([
+      "SUPABASE_DATABASE_URL",
+      "VITE_SUPABASE_URL",
+      "VITE_SUPABASE_ANON_KEY",
+    ]);
+  } catch (error) {
+    return handleMissingEnvironmentError(error, "inspect-library");
+  }
+
+  const authenticated = await verifyAuthenticatedUser(req);
+  if (!authenticated) {
+    return unauthorized();
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return validationError("Invalid JSON in request body");
+  }
+
+  const validation = validateLibraryInspectionRequest(body);
+  if (!validation.success) {
+    return validationError(
+      "Validation failed",
+      getValidationDetails(validation.issues),
+    );
+  }
+
+  const publicUrl = await resolvePublicHttpUrl(validation.output.url);
+  if (!publicUrl) {
+    return validationError("Validation failed", {
+      url: [PUBLIC_URL_ERROR],
+    });
+  }
+
+  try {
+    const metadata = await extractMetadata(publicUrl);
+    if (metadata.error) {
+      await recordInspectionFailure();
+      return serviceUnavailable(INSPECTION_ERROR);
+    }
+
+    return ok({
+      title: metadata.title,
+      description: metadata.description,
+    });
+  } catch {
+    await recordInspectionFailure();
+    return serviceUnavailable(INSPECTION_ERROR);
+  }
+};
+
+export const config: Config = {
+  path: "/api/library/inspect",
+  method: "POST",
+};

--- a/netlify/functions/inspect-library.mts
+++ b/netlify/functions/inspect-library.mts
@@ -1,48 +1,33 @@
 import type { Config, Context } from "@netlify/functions";
-import type { BaseIssue } from "valibot";
 
 import {
   assertRequiredEnv,
   captureError,
+  consumeSubmissionRateLimit,
+  createSubmissionRateLimitKey,
+  dependencyUnavailable,
   flushSentry,
+  getSubmissionRateLimitConfig,
   handleMissingEnvironmentError,
   initSentry,
   methodNotAllowed,
   ok,
   serviceUnavailable,
+  tooManyRequests,
   unauthorized,
   validationError,
   verifyAuthenticatedUser,
 } from "./lib";
+import { handleInvalidEnvironmentError } from "./lib/env";
 import { resolvePublicHttpUrl } from "./lib/public-url";
+import type { SubmissionRateLimitConfig } from "./lib/submission-rate-limit";
+import { getValidationDetails } from "./lib/validation";
 import { extractMetadata } from "../../src/lib/services/metadata";
 import { validateLibraryInspectionRequest } from "../../src/lib/validation";
 
 const PUBLIC_URL_ERROR = "Please enter a publicly reachable HTTP/HTTPS URL";
 const INSPECTION_ERROR =
   "We couldn't inspect this URL right now. You can still save it to your library.";
-
-function getIssueField(issue: BaseIssue<unknown>): string {
-  const path = issue.path
-    ?.map((pathItem) => pathItem.key)
-    .filter(
-      (key): key is string | number =>
-        typeof key === "string" || typeof key === "number",
-    );
-
-  return path && path.length > 0 ? path.join(".") : "form";
-}
-
-function getValidationDetails(
-  issues: readonly BaseIssue<unknown>[],
-): Record<string, string[]> {
-  return issues.reduce<Record<string, string[]>>((details, issue) => {
-    const field = getIssueField(issue);
-    details[field] ??= [];
-    details[field].push(issue.message);
-    return details;
-  }, {});
-}
 
 /** Records inspection failures without including request or user data. */
 async function recordInspectionFailure(): Promise<void> {
@@ -75,6 +60,36 @@ export default async (req: Request, _context: Context) => {
     return unauthorized();
   }
 
+  let rateLimitConfig: SubmissionRateLimitConfig;
+  let keyHash: string;
+  try {
+    rateLimitConfig = getSubmissionRateLimitConfig();
+    keyHash = createSubmissionRateLimitKey(
+      { authenticated, clientIp: undefined },
+      rateLimitConfig.secret,
+      "library-inspection",
+    );
+  } catch (error) {
+    return handleInvalidEnvironmentError(error, "inspect-library");
+  }
+
+  try {
+    const allowed = await consumeSubmissionRateLimit(keyHash, rateLimitConfig);
+    if (!allowed) {
+      return tooManyRequests();
+    }
+  } catch {
+    captureError(
+      new Error("Library inspection rate limit datastore operation failed"),
+      {
+        function: "inspect-library",
+        dependency: "submission-rate-limit-store",
+      },
+    );
+    await flushSentry();
+    return dependencyUnavailable();
+  }
+
   let body: unknown;
   try {
     body = await req.json();
@@ -90,15 +105,17 @@ export default async (req: Request, _context: Context) => {
     );
   }
 
-  const publicUrl = await resolvePublicHttpUrl(validation.output.url);
-  if (!publicUrl) {
+  const publicTarget = await resolvePublicHttpUrl(validation.output.url);
+  if (!publicTarget) {
     return validationError("Validation failed", {
       url: [PUBLIC_URL_ERROR],
     });
   }
 
   try {
-    const metadata = await extractMetadata(publicUrl);
+    const metadata = await extractMetadata(publicTarget.url, {
+      dispatcher: publicTarget.dispatcher,
+    });
     if (metadata.error) {
       await recordInspectionFailure();
       return serviceUnavailable(INSPECTION_ERROR);
@@ -111,6 +128,8 @@ export default async (req: Request, _context: Context) => {
   } catch {
     await recordInspectionFailure();
     return serviceUnavailable(INSPECTION_ERROR);
+  } finally {
+    await publicTarget.dispatcher.close();
   }
 };
 

--- a/netlify/functions/lib/__tests__/public-url.test.ts
+++ b/netlify/functions/lib/__tests__/public-url.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LookupFunction } from "node:net";
+import type { buildConnector } from "undici";
+
+const agentState = vi.hoisted(() => ({
+  agentOptions: null as { connect?: buildConnector.connector } | null,
+  connectorOptions: null as { lookup?: LookupFunction } | null,
+  baseConnector: vi.fn(),
+}));
+
+vi.mock("undici", () => ({
+  Agent: class MockAgent {
+    constructor(options: typeof agentState.agentOptions) {
+      agentState.agentOptions = options;
+    }
+
+    close = vi.fn().mockResolvedValue(undefined);
+  },
+  buildConnector: vi.fn((options) => {
+    agentState.connectorOptions = options;
+    return agentState.baseConnector;
+  }),
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
+}));
+
+import { lookup } from "node:dns/promises";
+
+import { resolvePublicHttpUrl } from "../public-url";
+
+describe("resolvePublicHttpUrl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentState.agentOptions = null;
+    agentState.connectorOptions = null;
+    vi.mocked(lookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+    ] as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("revalidates DNS in the connection lookup and pins the returned address", async () => {
+    const resolved = await resolvePublicHttpUrl("https://example.com/resource");
+    const connectionLookup = agentState.connectorOptions?.lookup;
+
+    expect(resolved?.url).toBe("https://example.com/resource");
+    expect(connectionLookup).toBeTypeOf("function");
+
+    const callback = vi.fn();
+    connectionLookup?.("example.com", { family: 0, all: false }, callback);
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+
+    expect(lookup).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledWith(null, "93.184.216.34", 4);
+  });
+
+  it("rejects a hostname that rebinds to a private address at connection time", async () => {
+    vi.mocked(lookup)
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }] as never)
+      .mockResolvedValueOnce([{ address: "127.0.0.1", family: 4 }] as never);
+    await resolvePublicHttpUrl("https://example.com/resource");
+    const connectionLookup = agentState.connectorOptions?.lookup;
+    const callback = vi.fn();
+
+    connectionLookup?.("example.com", { family: 0, all: false }, callback);
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+
+    expect(callback.mock.calls[0]?.[0]).toMatchObject({ code: "EACCES" });
+  });
+
+  it("rejects a private IP redirect in the connection path", async () => {
+    await resolvePublicHttpUrl("https://example.com/resource");
+    const connector = agentState.agentOptions?.connect;
+    const callback = vi.fn();
+
+    connector?.(
+      {
+        hostname: "127.0.0.1",
+        protocol: "http:",
+        port: "80",
+      },
+      callback,
+    );
+
+    expect(callback.mock.calls[0]?.[0]).toMatchObject({ code: "EACCES" });
+    expect(agentState.baseConnector).not.toHaveBeenCalled();
+  });
+
+  it("rejects a localhost redirect before connection-time DNS", async () => {
+    await resolvePublicHttpUrl("https://example.com/resource");
+    const connectionLookup = agentState.connectorOptions?.lookup;
+    const callback = vi.fn();
+
+    connectionLookup?.(
+      "service.localhost",
+      { family: 0, all: false },
+      callback,
+    );
+
+    expect(callback.mock.calls[0]?.[0]).toMatchObject({ code: "EACCES" });
+    expect(lookup).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when DNS lookup exceeds the timeout", async () => {
+    vi.useFakeTimers();
+    vi.mocked(lookup).mockReturnValue(new Promise(() => {}) as never);
+
+    const resolution = resolvePublicHttpUrl("https://example.com/resource");
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await expect(resolution).resolves.toBeNull();
+  });
+
+  it("rejects mixed public and private DNS answers", async () => {
+    vi.mocked(lookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "10.0.0.1", family: 4 },
+    ] as never);
+
+    await expect(
+      resolvePublicHttpUrl("https://example.com/resource"),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects hexadecimal IPv4-mapped IPv6 loopback addresses", async () => {
+    await expect(
+      resolvePublicHttpUrl("http://[::ffff:7f00:1]/admin"),
+    ).resolves.toBeNull();
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});

--- a/netlify/functions/lib/__tests__/public-url.test.ts
+++ b/netlify/functions/lib/__tests__/public-url.test.ts
@@ -133,4 +133,21 @@ describe("resolvePublicHttpUrl", () => {
     ).resolves.toBeNull();
     expect(lookup).not.toHaveBeenCalled();
   });
+
+  it("rejects deprecated IPv4-compatible IPv6 loopback addresses", async () => {
+    await expect(
+      resolvePublicHttpUrl("http://[::127.0.0.1]/admin"),
+    ).resolves.toBeNull();
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a private IPv4 suffix after a public IPv6 prefix as mapped", async () => {
+    vi.mocked(lookup).mockResolvedValue([
+      { address: "2001:4860::ffff:127.0.0.1", family: 6 },
+    ] as never);
+
+    await expect(
+      resolvePublicHttpUrl("https://example.com/resource"),
+    ).resolves.toMatchObject({ url: "https://example.com/resource" });
+  });
 });

--- a/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
+++ b/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
@@ -206,6 +206,30 @@ describe("submission rate limit", () => {
     }
   });
 
+  it("reports invalid inspection fields through the shared loader", () => {
+    const restore = setRateLimitEnvironment({
+      INSPECTION_RATE_LIMIT_SECRET: "b".repeat(64),
+      INSPECTION_RATE_LIMIT_MAX_ATTEMPTS: "not-a-number",
+      INSPECTION_RATE_LIMIT_WINDOW_SECONDS: "600",
+    });
+
+    try {
+      let thrownError: unknown;
+      try {
+        getInspectionRateLimitConfig();
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(InvalidEnvironmentError);
+      expect(thrownError).toMatchObject({
+        invalidKeys: ["INSPECTION_RATE_LIMIT_MAX_ATTEMPTS"],
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it("declares the HMAC secret as sensitive external Varlock config", () => {
     expect(environmentSchema).toContain(
       "# @type=string(isLength=64,matches=/^[0-9A-Fa-f]{64}$/) @sensitive\nSUBMISSION_RATE_LIMIT_SECRET=",

--- a/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
+++ b/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
@@ -13,6 +13,7 @@ import { InvalidEnvironmentError } from "../env";
 import {
   consumeSubmissionRateLimit,
   createSubmissionRateLimitKey,
+  getInspectionRateLimitConfig,
   getSubmissionRateLimitConfig,
   SUBMISSION_RATE_LIMIT_CLEANUP_BATCH_SIZE,
   SUBMISSION_RATE_LIMIT_RETENTION_SECONDS,
@@ -183,12 +184,37 @@ describe("submission rate limit", () => {
     }
   });
 
+  it("reads inspection limits independently from submission limits", () => {
+    const restore = setRateLimitEnvironment({
+      INSPECTION_RATE_LIMIT_SECRET: "b".repeat(64),
+      INSPECTION_RATE_LIMIT_MAX_ATTEMPTS: "30",
+      INSPECTION_RATE_LIMIT_WINDOW_SECONDS: "600",
+      SUBMISSION_RATE_LIMIT_SECRET: config.secret,
+      SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: "5",
+      SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: "3600",
+    });
+
+    try {
+      expect(getInspectionRateLimitConfig()).toEqual({
+        secret: "b".repeat(64),
+        maxAttempts: 30,
+        windowSeconds: 600,
+      });
+      expect(getSubmissionRateLimitConfig()).toEqual(config);
+    } finally {
+      restore();
+    }
+  });
+
   it("declares the HMAC secret as sensitive external Varlock config", () => {
     expect(environmentSchema).toContain(
       "# @type=string(isLength=64,matches=/^[0-9A-Fa-f]{64}$/) @sensitive\nSUBMISSION_RATE_LIMIT_SECRET=",
     );
     expect(environmentSchema).not.toContain(
       "# @type=string(isLength=64,matches=/^[0-9A-Fa-f]{64}$/) @sensitive @required\nSUBMISSION_RATE_LIMIT_SECRET=",
+    );
+    expect(environmentSchema).toContain(
+      "# @type=string(isLength=64,matches=/^[0-9A-Fa-f]{64}$/) @sensitive\nINSPECTION_RATE_LIMIT_SECRET=",
     );
   });
 

--- a/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
+++ b/netlify/functions/lib/__tests__/submission-rate-limit.test.ts
@@ -119,6 +119,25 @@ describe("submission rate limit", () => {
     expect(authenticatedKey).not.toContain(authenticated.user.id);
   });
 
+  it("uses separate HMAC keys for independently throttled features", () => {
+    const authenticated = {
+      user: { id: "11111111-1111-4111-8111-111111111111" },
+      isAdmin: false,
+    } as AuthenticatedUser;
+    const submissionKey = createSubmissionRateLimitKey(
+      { authenticated, clientIp: undefined },
+      config.secret,
+    );
+    const inspectionKey = createSubmissionRateLimitKey(
+      { authenticated, clientIp: undefined },
+      config.secret,
+      "library-inspection",
+    );
+
+    expect(inspectionKey).not.toBe(submissionKey);
+    expect(inspectionKey).toMatch(/^[a-f0-9]{64}$/);
+  });
+
   it("fails closed when anonymous Netlify context has no client IP", () => {
     expect(() =>
       createSubmissionRateLimitKey(

--- a/netlify/functions/lib/index.ts
+++ b/netlify/functions/lib/index.ts
@@ -17,6 +17,7 @@ export { assertRequiredEnv, handleMissingEnvironmentError } from "./env";
 export {
   consumeSubmissionRateLimit,
   createSubmissionRateLimitKey,
+  getInspectionRateLimitConfig,
   getSubmissionRateLimitConfig,
 } from "./submission-rate-limit";
 export {

--- a/netlify/functions/lib/public-url.ts
+++ b/netlify/functions/lib/public-url.ts
@@ -1,5 +1,9 @@
 import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
+import { isIP, type LookupFunction } from "node:net";
+
+import { Agent, buildConnector } from "undici";
+
+const DNS_LOOKUP_TIMEOUT_MS = 3_000;
 
 const BLOCKED_HOSTNAMES = new Set([
   "localhost",
@@ -39,6 +43,14 @@ function getHostname(url: URL): string {
     .replace(/\.$/, "");
 }
 
+function isBlockedHostname(hostname: string): boolean {
+  const normalizedHostname = hostname.toLowerCase().replace(/\.$/, "");
+  return (
+    BLOCKED_HOSTNAMES.has(normalizedHostname) ||
+    normalizedHostname.endsWith(".localhost")
+  );
+}
+
 function ipv4ToNumber(address: string): number | null {
   const octets = address.split(".").map((octet) => Number(octet));
 
@@ -75,11 +87,53 @@ function isBlockedIpv4Address(address: string): boolean {
   );
 }
 
+function getMappedIpv4Address(address: string): string | null {
+  const normalizedAddress = address.toLowerCase().split("%")[0];
+  const dottedAddress = normalizedAddress.match(
+    /(?:^|:)ffff:(\d+\.\d+\.\d+\.\d+)$/,
+  )?.[1];
+  if (dottedAddress) {
+    return dottedAddress;
+  }
+
+  const [head = "", tail = ""] = normalizedAddress.split("::");
+  const headParts = head ? head.split(":") : [];
+  const tailParts = tail ? tail.split(":") : [];
+  const missingParts = 8 - headParts.length - tailParts.length;
+  const parts = [
+    ...headParts,
+    ...Array.from({ length: Math.max(0, missingParts) }, () => "0"),
+    ...tailParts,
+  ];
+  if (
+    parts.length !== 8 ||
+    parts.slice(0, 5).some((part) => Number.parseInt(part || "0", 16) !== 0) ||
+    Number.parseInt(parts[5] || "0", 16) !== 0xffff
+  ) {
+    return null;
+  }
+
+  const high = Number.parseInt(parts[6] || "0", 16);
+  const low = Number.parseInt(parts[7] || "0", 16);
+  if (
+    !Number.isInteger(high) ||
+    !Number.isInteger(low) ||
+    high < 0 ||
+    high > 0xffff ||
+    low < 0 ||
+    low > 0xffff
+  ) {
+    return null;
+  }
+
+  return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+}
+
 function isBlockedIpv6Address(address: string): boolean {
   const normalizedAddress = address.toLowerCase();
-  const mappedIpv4 = normalizedAddress.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (mappedIpv4?.[1]) {
-    return isBlockedIpv4Address(mappedIpv4[1]);
+  const mappedIpv4 = getMappedIpv4Address(normalizedAddress);
+  if (mappedIpv4) {
+    return isBlockedIpv4Address(mappedIpv4);
   }
 
   const firstHextet = Number.parseInt(
@@ -109,33 +163,120 @@ function isBlockedIpAddress(address: string): boolean {
   return false;
 }
 
-/** Resolves an HTTP(S) URL only when its hostname maps exclusively to public addresses. */
+async function lookupPublicAddresses(hostname: string) {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const addresses = await Promise.race([
+      lookup(hostname, { all: true, verbatim: true }).catch(() => []),
+      new Promise<never[]>((resolve) => {
+        timeoutId = setTimeout(() => resolve([]), DNS_LOOKUP_TIMEOUT_MS);
+        timeoutId.unref?.();
+      }),
+    ]);
+
+    return addresses.length > 0 &&
+      addresses.every(({ address }) => !isBlockedIpAddress(address))
+      ? addresses
+      : [];
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function createPublicLookup(): LookupFunction {
+  return (hostname, options, callback) => {
+    if (isBlockedHostname(hostname)) {
+      const error = new Error(
+        "Hostname is not a public destination",
+      ) as NodeJS.ErrnoException;
+      error.code = "EACCES";
+      callback(error, "", 0);
+      return;
+    }
+
+    void lookupPublicAddresses(hostname).then((addresses) => {
+      const requestedFamily = options.family ?? 0;
+      const eligibleAddresses = requestedFamily
+        ? addresses.filter(({ family }) => family === requestedFamily)
+        : addresses;
+
+      if (eligibleAddresses.length === 0) {
+        const error = new Error(
+          "Hostname did not resolve to a public address",
+        ) as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        callback(error, "", 0);
+        return;
+      }
+
+      if (options.all) {
+        callback(null, eligibleAddresses);
+        return;
+      }
+
+      const [address] = eligibleAddresses;
+      callback(null, address.address, address.family);
+    });
+  };
+}
+
+function createPublicConnector() {
+  const connect = buildConnector({ lookup: createPublicLookup() });
+
+  return (
+    options: Parameters<typeof connect>[0],
+    callback: Parameters<typeof connect>[1],
+  ) => {
+    const hostname = options.hostname.replace(/^\[|\]$/g, "");
+    if (isIP(hostname) && isBlockedIpAddress(hostname)) {
+      const error = new Error(
+        "Connection target is not a public address",
+      ) as NodeJS.ErrnoException;
+      error.code = "EACCES";
+      callback(error, null);
+      return;
+    }
+
+    connect(options, callback);
+  };
+}
+
+export interface ResolvedPublicUrl {
+  url: string;
+  dispatcher: Agent;
+}
+
+/**
+ * Resolves a public HTTP(S) URL and creates a dispatcher that revalidates DNS
+ * at socket-connection time, pinning each connection to the returned address.
+ */
 export async function resolvePublicHttpUrl(
   value: string,
-): Promise<string | null> {
+): Promise<ResolvedPublicUrl | null> {
   const url = parseHttpUrl(value);
   if (!url) {
     return null;
   }
 
   const hostname = getHostname(url);
-  if (
-    BLOCKED_HOSTNAMES.has(hostname) ||
-    hostname.endsWith(".localhost") ||
-    isBlockedIpAddress(hostname)
-  ) {
+  if (isBlockedHostname(hostname) || isBlockedIpAddress(hostname)) {
     return null;
   }
 
   if (!isIP(hostname)) {
-    const addresses = await lookup(hostname, { all: true }).catch(() => []);
-    if (
-      addresses.length === 0 ||
-      addresses.some(({ address }) => isBlockedIpAddress(address))
-    ) {
+    const addresses = await lookupPublicAddresses(hostname);
+    if (addresses.length === 0) {
       return null;
     }
   }
 
-  return url.href;
+  return {
+    url: url.href,
+    dispatcher: new Agent({
+      connect: createPublicConnector(),
+    }),
+  };
 }

--- a/netlify/functions/lib/public-url.ts
+++ b/netlify/functions/lib/public-url.ts
@@ -1,0 +1,141 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "metadata",
+  "metadata.google.internal",
+]);
+
+const BLOCKED_IPV4_RANGES: readonly [
+  baseAddress: string,
+  prefixLength: number,
+][] = [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+];
+
+function parseHttpUrl(value: string): URL | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function getHostname(url: URL): string {
+  return url.hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/, "");
+}
+
+function ipv4ToNumber(address: string): number | null {
+  const octets = address.split(".").map((octet) => Number(octet));
+
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return null;
+  }
+
+  return octets.reduce((value, octet) => value * 256 + octet, 0) >>> 0;
+}
+
+function isIpv4InRange(
+  address: string,
+  baseAddress: string,
+  prefixLength: number,
+): boolean {
+  const addressNumber = ipv4ToNumber(address);
+  const baseNumber = ipv4ToNumber(baseAddress);
+
+  if (addressNumber === null || baseNumber === null) {
+    return false;
+  }
+
+  const mask =
+    prefixLength === 0 ? 0 : (0xffffffff << (32 - prefixLength)) >>> 0;
+  return (addressNumber & mask) === (baseNumber & mask);
+}
+
+function isBlockedIpv4Address(address: string): boolean {
+  return BLOCKED_IPV4_RANGES.some(([baseAddress, prefixLength]) =>
+    isIpv4InRange(address, baseAddress, prefixLength),
+  );
+}
+
+function isBlockedIpv6Address(address: string): boolean {
+  const normalizedAddress = address.toLowerCase();
+  const mappedIpv4 = normalizedAddress.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mappedIpv4?.[1]) {
+    return isBlockedIpv4Address(mappedIpv4[1]);
+  }
+
+  const firstHextet = Number.parseInt(
+    normalizedAddress.split(":")[0] || "0",
+    16,
+  );
+  return (
+    normalizedAddress === "::" ||
+    normalizedAddress === "::1" ||
+    (firstHextet & 0xfe00) === 0xfc00 ||
+    (firstHextet & 0xffc0) === 0xfe80 ||
+    (firstHextet & 0xff00) === 0xff00
+  );
+}
+
+function isBlockedIpAddress(address: string): boolean {
+  const ipVersion = isIP(address);
+
+  if (ipVersion === 4) {
+    return isBlockedIpv4Address(address);
+  }
+
+  if (ipVersion === 6) {
+    return isBlockedIpv6Address(address);
+  }
+
+  return false;
+}
+
+/** Resolves an HTTP(S) URL only when its hostname maps exclusively to public addresses. */
+export async function resolvePublicHttpUrl(
+  value: string,
+): Promise<string | null> {
+  const url = parseHttpUrl(value);
+  if (!url) {
+    return null;
+  }
+
+  const hostname = getHostname(url);
+  if (
+    BLOCKED_HOSTNAMES.has(hostname) ||
+    hostname.endsWith(".localhost") ||
+    isBlockedIpAddress(hostname)
+  ) {
+    return null;
+  }
+
+  if (!isIP(hostname)) {
+    const addresses = await lookup(hostname, { all: true }).catch(() => []);
+    if (
+      addresses.length === 0 ||
+      addresses.some(({ address }) => isBlockedIpAddress(address))
+    ) {
+      return null;
+    }
+  }
+
+  return url.href;
+}

--- a/netlify/functions/lib/public-url.ts
+++ b/netlify/functions/lib/public-url.ts
@@ -88,44 +88,60 @@ function isBlockedIpv4Address(address: string): boolean {
 }
 
 function getMappedIpv4Address(address: string): string | null {
-  const normalizedAddress = address.toLowerCase().split("%")[0];
-  const dottedAddress = normalizedAddress.match(
-    /(?:^|:)ffff:(\d+\.\d+\.\d+\.\d+)$/,
-  )?.[1];
-  if (dottedAddress) {
-    return dottedAddress;
+  let normalizedAddress = address.toLowerCase().split("%")[0];
+  const dottedMatch = normalizedAddress.match(/^(.*:)(\d+\.\d+\.\d+\.\d+)$/);
+  if (dottedMatch) {
+    const ipv4Number = ipv4ToNumber(dottedMatch[2]);
+    if (ipv4Number === null) {
+      return null;
+    }
+
+    normalizedAddress = `${dottedMatch[1]}${(ipv4Number >>> 16).toString(16)}:${(
+      ipv4Number & 0xffff
+    ).toString(16)}`;
   }
 
-  const [head = "", tail = ""] = normalizedAddress.split("::");
-  const headParts = head ? head.split(":") : [];
-  const tailParts = tail ? tail.split(":") : [];
-  const missingParts = 8 - headParts.length - tailParts.length;
-  const parts = [
-    ...headParts,
-    ...Array.from({ length: Math.max(0, missingParts) }, () => "0"),
-    ...tailParts,
-  ];
+  let parts: string[];
+  if (normalizedAddress.includes("::")) {
+    if (
+      normalizedAddress.indexOf("::") !== normalizedAddress.lastIndexOf("::")
+    ) {
+      return null;
+    }
+
+    const [head = "", tail = ""] = normalizedAddress.split("::");
+    const headParts = head ? head.split(":") : [];
+    const tailParts = tail ? tail.split(":") : [];
+    const missingParts = 8 - headParts.length - tailParts.length;
+    if (missingParts < 1) {
+      return null;
+    }
+    parts = [
+      ...headParts,
+      ...Array.from({ length: missingParts }, () => "0"),
+      ...tailParts,
+    ];
+  } else {
+    parts = normalizedAddress.split(":");
+  }
+
   if (
     parts.length !== 8 ||
-    parts.slice(0, 5).some((part) => Number.parseInt(part || "0", 16) !== 0) ||
-    Number.parseInt(parts[5] || "0", 16) !== 0xffff
+    parts.some((part) => !/^[0-9a-f]{1,4}$/.test(part))
   ) {
     return null;
   }
 
-  const high = Number.parseInt(parts[6] || "0", 16);
-  const low = Number.parseInt(parts[7] || "0", 16);
-  if (
-    !Number.isInteger(high) ||
-    !Number.isInteger(low) ||
-    high < 0 ||
-    high > 0xffff ||
-    low < 0 ||
-    low > 0xffff
-  ) {
+  const hextets = parts.map((part) => Number.parseInt(part, 16));
+  const hasZeroPrefix = hextets.slice(0, 5).every((part) => part === 0);
+  const isMapped = hasZeroPrefix && hextets[5] === 0xffff;
+  const isCompatible = hasZeroPrefix && hextets[5] === 0;
+  if (!isMapped && !isCompatible) {
     return null;
   }
 
+  const high = hextets[6];
+  const low = hextets[7];
   return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
 }
 

--- a/netlify/functions/lib/submission-rate-limit.ts
+++ b/netlify/functions/lib/submission-rate-limit.ts
@@ -92,6 +92,7 @@ export function getSubmissionRateLimitConfig(): SubmissionRateLimitConfig {
 export function createSubmissionRateLimitKey(
   identity: SubmissionRateLimitIdentity,
   secret: string,
+  scope = "submission",
 ): string {
   const subject = identity.authenticated
     ? `user:${identity.authenticated.user.id}`
@@ -101,7 +102,9 @@ export function createSubmissionRateLimitKey(
     throw new InvalidEnvironmentError(["NETLIFY_CONTEXT_IP"]);
   }
 
-  return createHmac("sha256", secret).update(subject).digest("hex");
+  const scopedSubject =
+    scope === "submission" ? subject : `${scope}:${subject}`;
+  return createHmac("sha256", secret).update(scopedSubject).digest("hex");
 }
 
 /** Removes a bounded batch of expired rows older than the retention period. */

--- a/netlify/functions/lib/submission-rate-limit.ts
+++ b/netlify/functions/lib/submission-rate-limit.ts
@@ -14,6 +14,12 @@ const SUBMISSION_RATE_LIMIT_ENV_KEYS = [
   "SUBMISSION_RATE_LIMIT_WINDOW_SECONDS",
 ] as const;
 
+const INSPECTION_RATE_LIMIT_ENV_KEYS = [
+  "INSPECTION_RATE_LIMIT_SECRET",
+  "INSPECTION_RATE_LIMIT_MAX_ATTEMPTS",
+  "INSPECTION_RATE_LIMIT_WINDOW_SECONDS",
+] as const;
+
 export const SUBMISSION_RATE_LIMIT_RETENTION_SECONDS = 30 * 24 * 60 * 60;
 export const SUBMISSION_RATE_LIMIT_CLEANUP_BATCH_SIZE = 100;
 
@@ -44,6 +50,24 @@ export const submissionRateLimitEnvironmentSchema = v.object({
     v.maxValue(1000),
   ),
   SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: v.pipe(
+    positiveIntegerStringSchema,
+    v.maxValue(86_400),
+  ),
+});
+
+const inspectionRateLimitEnvironmentSchema = v.object({
+  INSPECTION_RATE_LIMIT_SECRET: v.pipe(
+    v.string(),
+    v.regex(
+      /^[0-9A-Fa-f]{64}$/,
+      "Must contain exactly 64 hexadecimal characters",
+    ),
+  ),
+  INSPECTION_RATE_LIMIT_MAX_ATTEMPTS: v.pipe(
+    positiveIntegerStringSchema,
+    v.maxValue(1000),
+  ),
+  INSPECTION_RATE_LIMIT_WINDOW_SECONDS: v.pipe(
     positiveIntegerStringSchema,
     v.maxValue(86_400),
   ),
@@ -85,6 +109,34 @@ export function getSubmissionRateLimitConfig(): SubmissionRateLimitConfig {
     secret: validation.output.SUBMISSION_RATE_LIMIT_SECRET,
     maxAttempts: validation.output.SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS,
     windowSeconds: validation.output.SUBMISSION_RATE_LIMIT_WINDOW_SECONDS,
+  };
+}
+
+/** Reads and validates the dedicated interactive inspection throttle. */
+export function getInspectionRateLimitConfig(): SubmissionRateLimitConfig {
+  const environment = Object.fromEntries(
+    INSPECTION_RATE_LIMIT_ENV_KEYS.map((key) => [key, getEnv(key)]),
+  );
+  const validation = v.safeParse(
+    inspectionRateLimitEnvironmentSchema,
+    environment,
+  );
+
+  if (!validation.success) {
+    const invalidKeys = [
+      ...new Set(
+        validation.issues
+          .map((issue) => issue.path?.[0]?.key)
+          .filter((key): key is string => typeof key === "string"),
+      ),
+    ];
+    throw new InvalidEnvironmentError(invalidKeys);
+  }
+
+  return {
+    secret: validation.output.INSPECTION_RATE_LIMIT_SECRET,
+    maxAttempts: validation.output.INSPECTION_RATE_LIMIT_MAX_ATTEMPTS,
+    windowSeconds: validation.output.INSPECTION_RATE_LIMIT_WINDOW_SECONDS,
   };
 }
 

--- a/netlify/functions/lib/submission-rate-limit.ts
+++ b/netlify/functions/lib/submission-rate-limit.ts
@@ -36,41 +36,33 @@ const positiveIntegerStringSchema = v.pipe(
   v.minValue(1),
 );
 
+const rateLimitSecretSchema = v.pipe(
+  v.string(),
+  v.regex(
+    /^[0-9A-Fa-f]{64}$/,
+    "Must contain exactly 64 hexadecimal characters",
+  ),
+);
+const rateLimitMaxAttemptsSchema = v.pipe(
+  positiveIntegerStringSchema,
+  v.maxValue(1000),
+);
+const rateLimitWindowSecondsSchema = v.pipe(
+  positiveIntegerStringSchema,
+  v.maxValue(86_400),
+);
+
 /** Validates the server-only controls that tune public submission throttling. */
 export const submissionRateLimitEnvironmentSchema = v.object({
-  SUBMISSION_RATE_LIMIT_SECRET: v.pipe(
-    v.string(),
-    v.regex(
-      /^[0-9A-Fa-f]{64}$/,
-      "Must contain exactly 64 hexadecimal characters",
-    ),
-  ),
-  SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: v.pipe(
-    positiveIntegerStringSchema,
-    v.maxValue(1000),
-  ),
-  SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: v.pipe(
-    positiveIntegerStringSchema,
-    v.maxValue(86_400),
-  ),
+  SUBMISSION_RATE_LIMIT_SECRET: rateLimitSecretSchema,
+  SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS: rateLimitMaxAttemptsSchema,
+  SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: rateLimitWindowSecondsSchema,
 });
 
 const inspectionRateLimitEnvironmentSchema = v.object({
-  INSPECTION_RATE_LIMIT_SECRET: v.pipe(
-    v.string(),
-    v.regex(
-      /^[0-9A-Fa-f]{64}$/,
-      "Must contain exactly 64 hexadecimal characters",
-    ),
-  ),
-  INSPECTION_RATE_LIMIT_MAX_ATTEMPTS: v.pipe(
-    positiveIntegerStringSchema,
-    v.maxValue(1000),
-  ),
-  INSPECTION_RATE_LIMIT_WINDOW_SECONDS: v.pipe(
-    positiveIntegerStringSchema,
-    v.maxValue(86_400),
-  ),
+  INSPECTION_RATE_LIMIT_SECRET: rateLimitSecretSchema,
+  INSPECTION_RATE_LIMIT_MAX_ATTEMPTS: rateLimitMaxAttemptsSchema,
+  INSPECTION_RATE_LIMIT_WINDOW_SECONDS: rateLimitWindowSecondsSchema,
 });
 
 export interface SubmissionRateLimitConfig {
@@ -84,15 +76,21 @@ interface SubmissionRateLimitIdentity {
   clientIp: string | undefined;
 }
 
-/** Reads and validates the server-only rate-limit configuration. */
-export function getSubmissionRateLimitConfig(): SubmissionRateLimitConfig {
+type RateLimitConfigOutputFields<TOutput> = Record<
+  keyof SubmissionRateLimitConfig,
+  keyof TOutput & string
+>;
+
+/** Reads, validates, and normalizes a rate-limit environment configuration. */
+function loadRateLimitConfig<TOutput extends Record<string, unknown>>(
+  environmentKeys: readonly (keyof TOutput & string)[],
+  schema: v.GenericSchema<unknown, TOutput>,
+  outputFields: RateLimitConfigOutputFields<TOutput>,
+): SubmissionRateLimitConfig {
   const environment = Object.fromEntries(
-    SUBMISSION_RATE_LIMIT_ENV_KEYS.map((key) => [key, getEnv(key)]),
+    environmentKeys.map((key) => [key, getEnv(key)]),
   );
-  const validation = v.safeParse(
-    submissionRateLimitEnvironmentSchema,
-    environment,
-  );
+  const validation = v.safeParse(schema, environment);
 
   if (!validation.success) {
     const invalidKeys = [
@@ -105,39 +103,44 @@ export function getSubmissionRateLimitConfig(): SubmissionRateLimitConfig {
     throw new InvalidEnvironmentError(invalidKeys);
   }
 
-  return {
-    secret: validation.output.SUBMISSION_RATE_LIMIT_SECRET,
-    maxAttempts: validation.output.SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS,
-    windowSeconds: validation.output.SUBMISSION_RATE_LIMIT_WINDOW_SECONDS,
-  };
+  const secret = validation.output[outputFields.secret];
+  const maxAttempts = validation.output[outputFields.maxAttempts];
+  const windowSeconds = validation.output[outputFields.windowSeconds];
+  if (
+    typeof secret !== "string" ||
+    typeof maxAttempts !== "number" ||
+    typeof windowSeconds !== "number"
+  ) {
+    throw new InvalidEnvironmentError(Object.values(outputFields));
+  }
+
+  return { secret, maxAttempts, windowSeconds };
+}
+
+/** Reads and validates the server-only rate-limit configuration. */
+export function getSubmissionRateLimitConfig(): SubmissionRateLimitConfig {
+  return loadRateLimitConfig(
+    SUBMISSION_RATE_LIMIT_ENV_KEYS,
+    submissionRateLimitEnvironmentSchema,
+    {
+      secret: "SUBMISSION_RATE_LIMIT_SECRET",
+      maxAttempts: "SUBMISSION_RATE_LIMIT_MAX_ATTEMPTS",
+      windowSeconds: "SUBMISSION_RATE_LIMIT_WINDOW_SECONDS",
+    },
+  );
 }
 
 /** Reads and validates the dedicated interactive inspection throttle. */
 export function getInspectionRateLimitConfig(): SubmissionRateLimitConfig {
-  const environment = Object.fromEntries(
-    INSPECTION_RATE_LIMIT_ENV_KEYS.map((key) => [key, getEnv(key)]),
-  );
-  const validation = v.safeParse(
+  return loadRateLimitConfig(
+    INSPECTION_RATE_LIMIT_ENV_KEYS,
     inspectionRateLimitEnvironmentSchema,
-    environment,
+    {
+      secret: "INSPECTION_RATE_LIMIT_SECRET",
+      maxAttempts: "INSPECTION_RATE_LIMIT_MAX_ATTEMPTS",
+      windowSeconds: "INSPECTION_RATE_LIMIT_WINDOW_SECONDS",
+    },
   );
-
-  if (!validation.success) {
-    const invalidKeys = [
-      ...new Set(
-        validation.issues
-          .map((issue) => issue.path?.[0]?.key)
-          .filter((key): key is string => typeof key === "string"),
-      ),
-    ];
-    throw new InvalidEnvironmentError(invalidKeys);
-  }
-
-  return {
-    secret: validation.output.INSPECTION_RATE_LIMIT_SECRET,
-    maxAttempts: validation.output.INSPECTION_RATE_LIMIT_MAX_ATTEMPTS,
-    windowSeconds: validation.output.INSPECTION_RATE_LIMIT_WINDOW_SECONDS,
-  };
 }
 
 /** Creates the non-reversible, server-only rate-limit key for a submitter. */

--- a/netlify/functions/lib/submissions.ts
+++ b/netlify/functions/lib/submissions.ts
@@ -1,8 +1,6 @@
 import type { Context } from "@netlify/functions";
 import type { BaseIssue } from "valibot";
 import { sql } from "drizzle-orm";
-import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
 
 import {
   getVerifiedDisplayName,
@@ -28,6 +26,7 @@ import {
   validationError,
 } from "./responses";
 import { captureError, flushSentry, initSentry } from "./sentry";
+import { resolvePublicHttpUrl } from "./public-url";
 import {
   consumeSubmissionRateLimit,
   createSubmissionRateLimitKey,
@@ -58,27 +57,7 @@ import {
 import { getGithubUsernameFromProfileUrl } from "../../../src/lib/github";
 
 const FALLBACK_IMAGE = "/makerbench-fallback.png";
-const BLOCKED_HOSTNAMES = new Set([
-  "localhost",
-  "metadata",
-  "metadata.google.internal",
-]);
 const PUBLIC_URL_ERROR = "Please enter a publicly reachable HTTP/HTTPS URL";
-const BLOCKED_IPV4_RANGES: readonly [
-  baseAddress: string,
-  prefixLength: number,
-][] = [
-  ["0.0.0.0", 8],
-  ["10.0.0.0", 8],
-  ["100.64.0.0", 10],
-  ["127.0.0.0", 8],
-  ["169.254.0.0", 16],
-  ["172.16.0.0", 12],
-  ["192.168.0.0", 16],
-  ["198.18.0.0", 15],
-  ["224.0.0.0", 4],
-  ["240.0.0.0", 4],
-];
 
 type PublicListingSubmissionType = Exclude<PublicSubmissionType, "tool">;
 
@@ -167,120 +146,6 @@ function normalizeTags(tags: string[]): string[] {
         .filter((tag) => tag.length > 0),
     ),
   ];
-}
-
-function parseHttpUrl(value: string): URL | null {
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
-  } catch {
-    return null;
-  }
-}
-
-function getHostname(url: URL): string {
-  return url.hostname
-    .toLowerCase()
-    .replace(/^\[|\]$/g, "")
-    .replace(/\.$/, "");
-}
-
-function ipv4ToNumber(address: string): number | null {
-  const octets = address.split(".").map((octet) => Number(octet));
-
-  if (
-    octets.length !== 4 ||
-    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
-  ) {
-    return null;
-  }
-
-  return octets.reduce((value, octet) => value * 256 + octet, 0) >>> 0;
-}
-
-function isIpv4InRange(
-  address: string,
-  baseAddress: string,
-  prefixLength: number,
-): boolean {
-  const addressNumber = ipv4ToNumber(address);
-  const baseNumber = ipv4ToNumber(baseAddress);
-
-  if (addressNumber === null || baseNumber === null) {
-    return false;
-  }
-
-  const mask =
-    prefixLength === 0 ? 0 : (0xffffffff << (32 - prefixLength)) >>> 0;
-  return (addressNumber & mask) === (baseNumber & mask);
-}
-
-function isBlockedIpv4Address(address: string): boolean {
-  return BLOCKED_IPV4_RANGES.some(([baseAddress, prefixLength]) =>
-    isIpv4InRange(address, baseAddress, prefixLength),
-  );
-}
-
-function isBlockedIpv6Address(address: string): boolean {
-  const normalizedAddress = address.toLowerCase();
-  const mappedIpv4 = normalizedAddress.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (mappedIpv4?.[1]) {
-    return isBlockedIpv4Address(mappedIpv4[1]);
-  }
-
-  const firstHextet = Number.parseInt(
-    normalizedAddress.split(":")[0] || "0",
-    16,
-  );
-  return (
-    normalizedAddress === "::" ||
-    normalizedAddress === "::1" ||
-    (firstHextet & 0xfe00) === 0xfc00 ||
-    (firstHextet & 0xffc0) === 0xfe80 ||
-    (firstHextet & 0xff00) === 0xff00
-  );
-}
-
-function isBlockedIpAddress(address: string): boolean {
-  const ipVersion = isIP(address);
-
-  if (ipVersion === 4) {
-    return isBlockedIpv4Address(address);
-  }
-
-  if (ipVersion === 6) {
-    return isBlockedIpv6Address(address);
-  }
-
-  return false;
-}
-
-async function resolvePublicHttpUrl(value: string): Promise<string | null> {
-  const url = parseHttpUrl(value);
-  if (!url) {
-    return null;
-  }
-
-  const hostname = getHostname(url);
-  if (
-    BLOCKED_HOSTNAMES.has(hostname) ||
-    hostname.endsWith(".localhost") ||
-    isBlockedIpAddress(hostname)
-  ) {
-    return null;
-  }
-
-  if (!isIP(hostname)) {
-    const addresses = await lookup(hostname, { all: true }).catch(() => []);
-    if (
-      addresses.length === 0 ||
-      addresses.some(({ address }) => isBlockedIpAddress(address))
-    ) {
-      return null;
-    }
-  }
-
-  return url.href;
 }
 
 /** Builds a canonical GitHub profile URL from either a submitted URL or username. */

--- a/netlify/functions/lib/submissions.ts
+++ b/netlify/functions/lib/submissions.ts
@@ -1,5 +1,4 @@
 import type { Context } from "@netlify/functions";
-import type { BaseIssue } from "valibot";
 import { sql } from "drizzle-orm";
 
 import {
@@ -38,6 +37,7 @@ import {
   recordSubmissionBlocklistEvent,
 } from "./submission-blocklist";
 import { normalizeUrl, parseAndNormalizeUrl } from "./url";
+import { getValidationDetails } from "./validation";
 import {
   publicListingsTable,
   resourcesTable,
@@ -89,28 +89,6 @@ interface ExistingPublicSubmission extends Record<string, unknown> {
 interface ToolImage {
   imageSource: "og" | "screenshot" | "fallback";
   imageUrl: string;
-}
-
-function getIssueField(issue: BaseIssue<unknown>): string {
-  const path = issue.path
-    ?.map((pathItem) => pathItem.key)
-    .filter(
-      (key): key is string | number =>
-        typeof key === "string" || typeof key === "number",
-    );
-
-  return path && path.length > 0 ? path.join(".") : "form";
-}
-
-function getValidationDetails(
-  issues: readonly BaseIssue<unknown>[],
-): Record<string, string[]> {
-  return issues.reduce<Record<string, string[]>>((details, issue) => {
-    const field = getIssueField(issue);
-    details[field] ??= [];
-    details[field].push(issue.message);
-    return details;
-  }, {});
 }
 
 function requestHasBearerToken(req: Request): boolean {
@@ -228,12 +206,13 @@ async function prepareToolImage(
   let imageUrl: string = FALLBACK_IMAGE;
   let imageSource: ToolImage["imageSource"] = "fallback";
 
-  const publicOgImage = metadata.ogImage
+  const publicOgImageTarget = metadata.ogImage
     ? await resolvePublicHttpUrl(metadata.ogImage)
     : null;
-  if (publicOgImage) {
-    imageUrl = publicOgImage;
+  if (publicOgImageTarget) {
+    imageUrl = publicOgImageTarget.url;
     imageSource = "og";
+    await publicOgImageTarget.dispatcher.close();
   } else {
     const screenshot = await captureScreenshot(normalizedUrl);
     if (screenshot.success && screenshot.buffer) {
@@ -541,13 +520,6 @@ export async function handlePublicSubmission(
     return dependencyUnavailable();
   }
 
-  const publicUrl = await resolvePublicHttpUrl(normalizedUrl);
-  if (!publicUrl) {
-    return validationError("Validation failed", {
-      url: [PUBLIC_URL_ERROR],
-    });
-  }
-
   const tags = normalizeTags(validation.output.tags);
   if (tags.length === 0) {
     return validationError("Validation failed", {
@@ -564,6 +536,14 @@ export async function handlePublicSubmission(
     return validationError("Validation failed", attributionDetails);
   }
 
+  const publicTarget = await resolvePublicHttpUrl(normalizedUrl);
+  if (!publicTarget) {
+    return validationError("Validation failed", {
+      url: [PUBLIC_URL_ERROR],
+    });
+  }
+  const publicUrl = publicTarget.url;
+
   const submissionContext: SubmissionContext = {
     authenticated,
     ...attribution,
@@ -573,7 +553,9 @@ export async function handlePublicSubmission(
   };
 
   try {
-    const metadata = await extractMetadata(publicUrl);
+    const metadata = await extractMetadata(publicUrl, {
+      dispatcher: publicTarget.dispatcher,
+    });
     const toolImage = isPublicListingSubmission(validation.output)
       ? null
       : await prepareToolImage(metadata, publicUrl);
@@ -642,5 +624,7 @@ export async function handlePublicSubmission(
     });
     await flushSentry();
     return serverError(getProcessingErrorMessage(validation.output.type));
+  } finally {
+    await publicTarget.dispatcher.close();
   }
 }

--- a/netlify/functions/lib/validation.ts
+++ b/netlify/functions/lib/validation.ts
@@ -1,0 +1,25 @@
+import type { BaseIssue } from "valibot";
+
+/** Maps a Valibot issue path to the API field name used in error details. */
+export function getIssueField(issue: BaseIssue<unknown>): string {
+  const path = issue.path
+    ?.map((pathItem) => pathItem.key)
+    .filter(
+      (key): key is string | number =>
+        typeof key === "string" || typeof key === "number",
+    );
+
+  return path && path.length > 0 ? path.join(".") : "form";
+}
+
+/** Aggregates Valibot issues into the shared field-to-messages API shape. */
+export function getValidationDetails(
+  issues: readonly BaseIssue<unknown>[],
+): Record<string, string[]> {
+  return issues.reduce<Record<string, string[]>>((details, issue) => {
+    const field = getIssueField(issue);
+    details[field] ??= [];
+    details[field].push(issue.message);
+    return details;
+  }, {});
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.15.1",
+    "undici": "^7.22.0",
     "valibot": "^1.4.2",
     "varlock": "^1.6.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-router-dom:
         specifier: ^7.15.1
         version: 7.15.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      undici:
+        specifier: ^7.22.0
+        version: 7.22.0
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@6.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 7.15.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       undici:
         specifier: ^7.22.0
-        version: 7.22.0
+        version: 7.28.0
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@6.0.3)
@@ -3768,8 +3768,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.4.0:
@@ -5815,7 +5815,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.22.0
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chromatic@16.10.0:
@@ -7280,7 +7280,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.22.0: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.4.0: {}
 

--- a/src/api/__tests__/library.test.ts
+++ b/src/api/__tests__/library.test.ts
@@ -63,4 +63,13 @@ describe("inspectLibraryResource", () => {
       message: "The page did not expose usable metadata.",
     });
   });
+
+  it("lets unexpected fetch failures propagate to the hook", async () => {
+    const networkError = new TypeError("network unavailable");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(networkError));
+
+    await expect(
+      inspectLibraryResource("https://example.com/resource", "verified-token"),
+    ).rejects.toBe(networkError);
+  });
 });

--- a/src/api/__tests__/library.test.ts
+++ b/src/api/__tests__/library.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { inspectLibraryResource } from "../library";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("inspectLibraryResource", () => {
+  it("sends the authenticated URL and validates the inspected metadata", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            title: "Inspected title",
+            description: "Inspected description",
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await inspectLibraryResource(
+      "https://example.com/resource",
+      "verified-token",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/library/inspect", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer verified-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ url: "https://example.com/resource" }),
+    });
+    expect(result).toEqual({
+      title: "Inspected title",
+      description: "Inspected description",
+    });
+  });
+
+  it("throws a typed error when inspection fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            success: false,
+            error: "The page did not expose usable metadata.",
+          }),
+          { status: 422, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(
+      inspectLibraryResource("https://example.com/resource", "verified-token"),
+    ).rejects.toMatchObject({
+      name: "BookmarkApiError",
+      status: 422,
+      message: "The page did not expose usable metadata.",
+    });
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -37,10 +37,12 @@ export {
 export {
   addLibraryResource,
   getLibraryResources,
+  inspectLibraryResource,
   type AddLibraryResourceResponse,
   type LibraryResource,
   type LibraryResponse,
   type LibraryTag,
+  type LibraryInspection,
 } from "./library";
 
 export {

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -1,7 +1,11 @@
 import * as v from "valibot";
 
 import { BookmarkApiError } from "./bookmarks";
-import type { PersonalResourceRequest } from "../lib/validation";
+import {
+  libraryInspectionResponseSchema,
+  type LibraryInspectionResponse,
+  type PersonalResourceRequest,
+} from "../lib/validation";
 
 const libraryTagSchema = v.object({
   id: v.string(),
@@ -41,10 +45,13 @@ const errorResponseSchema = v.object({
 
 export type LibraryTag = v.InferOutput<typeof libraryTagSchema>;
 export type LibraryResource = v.InferOutput<typeof libraryResourceSchema>;
-export type LibraryResponse = v.InferOutput<typeof libraryResponseSchema>["data"];
+export type LibraryResponse = v.InferOutput<
+  typeof libraryResponseSchema
+>["data"];
 export type AddLibraryResourceResponse = v.InferOutput<
   typeof addLibraryResourceResponseSchema
 >["data"];
+export type LibraryInspection = LibraryInspectionResponse["data"];
 
 function throwApiError(json: unknown, status: number): never {
   const parsed = v.safeParse(errorResponseSchema, json);
@@ -63,13 +70,21 @@ async function parseJsonResponse(response: Response): Promise<unknown> {
   }
 }
 
-function toBookmarkApiError(error: unknown, fallbackMessage: string): BookmarkApiError {
+function toBookmarkApiError(
+  error: unknown,
+  fallbackMessage: string,
+): BookmarkApiError {
   return error instanceof BookmarkApiError
     ? error
-    : new BookmarkApiError(error instanceof Error ? error.message : fallbackMessage, 500);
+    : new BookmarkApiError(
+        error instanceof Error ? error.message : fallbackMessage,
+        500,
+      );
 }
 
-export async function getLibraryResources(accessToken: string): Promise<LibraryResponse> {
+export async function getLibraryResources(
+  accessToken: string,
+): Promise<LibraryResponse> {
   try {
     const response = await fetch("/api/library", {
       headers: {
@@ -120,5 +135,36 @@ export async function addLibraryResource(
     return result.output.data;
   } catch (error) {
     throw toBookmarkApiError(error, "Failed to save this resource");
+  }
+}
+
+/** Inspects a resource URL for metadata without saving it. */
+export async function inspectLibraryResource(
+  url: string,
+  accessToken: string,
+): Promise<LibraryInspection> {
+  try {
+    const response = await fetch("/api/library/inspect", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ url }),
+    });
+    const json = await parseJsonResponse(response);
+
+    if (!response.ok) {
+      throwApiError(json, response.status);
+    }
+
+    const result = v.safeParse(libraryInspectionResponseSchema, json);
+    if (!result.success) {
+      throw new BookmarkApiError("Invalid response from server", 500);
+    }
+
+    return result.output.data;
+  } catch (error) {
+    throw toBookmarkApiError(error, "Failed to inspect this URL");
   }
 }

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -70,6 +70,7 @@ async function parseJsonResponse(response: Response): Promise<unknown> {
   }
 }
 
+/** Preserves BookmarkApiError values and wraps unknown failures as status 500 using their message or the fallback. */
 function toBookmarkApiError(
   error: unknown,
   fallbackMessage: string,
@@ -143,28 +144,24 @@ export async function inspectLibraryResource(
   url: string,
   accessToken: string,
 ): Promise<LibraryInspection> {
-  try {
-    const response = await fetch("/api/library/inspect", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ url }),
-    });
-    const json = await parseJsonResponse(response);
+  const response = await fetch("/api/library/inspect", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ url }),
+  });
+  const json = await parseJsonResponse(response);
 
-    if (!response.ok) {
-      throwApiError(json, response.status);
-    }
-
-    const result = v.safeParse(libraryInspectionResponseSchema, json);
-    if (!result.success) {
-      throw new BookmarkApiError("Invalid response from server", 500);
-    }
-
-    return result.output.data;
-  } catch (error) {
-    throw toBookmarkApiError(error, "Failed to inspect this URL");
+  if (!response.ok) {
+    throwApiError(json, response.status);
   }
+
+  const result = v.safeParse(libraryInspectionResponseSchema, json);
+  if (!result.success) {
+    throw new BookmarkApiError("Invalid response from server", 500);
+  }
+
+  return result.output.data;
 }

--- a/src/components/__tests__/LibraryPage.test.tsx
+++ b/src/components/__tests__/LibraryPage.test.tsx
@@ -1,0 +1,234 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BookmarkApiError } from "../../api";
+import { useAuth } from "../../hooks/useAuth";
+import { useLibraryResources } from "../../hooks/useLibraryResources";
+import { LibraryPage } from "../../pages/LibraryPage";
+
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../../hooks/useLibraryResources", () => ({
+  useLibraryResources: vi.fn(),
+}));
+
+const addResource = vi.fn();
+const inspectResource = vi.fn();
+const dismissInspectionError = vi.fn();
+const resetInspection = vi.fn();
+
+const authDefaults = {
+  identity: {
+    user: {
+      id: "user-1",
+      email: "ada@example.com",
+      displayName: "Ada Lovelace",
+      githubUsername: "ada-lovelace",
+      avatarUrl: null,
+    },
+    isAdmin: false,
+  },
+  session: null,
+  accessToken: "verified-token",
+  isAdmin: false,
+  isAuthenticated: true,
+  isLoading: false,
+  error: null,
+  signInWithGoogle: vi.fn(),
+  signInWithGitHub: vi.fn(),
+  signOut: vi.fn(),
+  refreshIdentity: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useAuth).mockReturnValue(authDefaults);
+  vi.mocked(useLibraryResources).mockReturnValue({
+    resources: [],
+    isLoading: false,
+    isSaving: false,
+    error: null,
+    isInspecting: false,
+    inspectionError: null,
+    addResource,
+    inspectResource,
+    dismissInspectionError,
+    resetInspection,
+    refresh: vi.fn(),
+  });
+  addResource.mockResolvedValue(true);
+});
+
+describe("LibraryPage metadata inspection", () => {
+  it("prefills editable metadata and sends edited values as save overrides", async () => {
+    inspectResource.mockResolvedValue({
+      title: "Extracted title",
+      description: "Extracted description",
+    });
+    const user = userEvent.setup();
+    render(<LibraryPage />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Resource URL" }),
+      "https://example.com/resource",
+    );
+    await user.click(screen.getByRole("button", { name: "Inspect URL" }));
+
+    expect(inspectResource).toHaveBeenCalledWith(
+      "https://example.com/resource",
+    );
+    expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue(
+      "Extracted title",
+    );
+    expect(screen.getByRole("textbox", { name: "Description" })).toHaveValue(
+      "Extracted description",
+    );
+
+    await user.clear(screen.getByRole("textbox", { name: "Title" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Title" }),
+      "  Edited title  ",
+    );
+    await user.clear(screen.getByRole("textbox", { name: "Description" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Description" }),
+      "  Edited description  ",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: /^tags/i }),
+      "research{Enter}",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Resource" }));
+
+    expect(addResource).toHaveBeenCalledWith({
+      url: "https://example.com/resource",
+      tags: ["research"],
+      notes: undefined,
+      title: "Edited title",
+      description: "Edited description",
+    });
+  });
+
+  it("omits unchanged inspected metadata from the save request", async () => {
+    inspectResource.mockResolvedValue({
+      title: "Extracted title",
+      description: "Extracted description",
+    });
+    const user = userEvent.setup();
+    render(<LibraryPage />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Resource URL" }),
+      "https://example.com/resource",
+    );
+    await user.click(screen.getByRole("button", { name: "Inspect URL" }));
+    await user.type(
+      screen.getByRole("textbox", { name: /^tags/i }),
+      "research{Enter}",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Resource" }));
+
+    expect(addResource).toHaveBeenCalledWith({
+      url: "https://example.com/resource",
+      tags: ["research"],
+      notes: undefined,
+    });
+  });
+
+  it("sends empty overrides when the user clears inspected metadata", async () => {
+    inspectResource.mockResolvedValue({
+      title: "Extracted title",
+      description: "Extracted description",
+    });
+    const user = userEvent.setup();
+    render(<LibraryPage />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Resource URL" }),
+      "https://example.com/resource",
+    );
+    await user.click(screen.getByRole("button", { name: "Inspect URL" }));
+    await user.clear(screen.getByRole("textbox", { name: "Title" }));
+    await user.clear(screen.getByRole("textbox", { name: "Description" }));
+    await user.type(
+      screen.getByRole("textbox", { name: /^tags/i }),
+      "research{Enter}",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Resource" }));
+
+    expect(addResource).toHaveBeenCalledWith({
+      url: "https://example.com/resource",
+      tags: ["research"],
+      notes: undefined,
+      title: "",
+      description: "",
+    });
+  });
+
+  it("shows inspection failures without preventing the resource from being saved", async () => {
+    inspectResource.mockResolvedValue(null);
+    vi.mocked(useLibraryResources).mockReturnValue({
+      resources: [],
+      isLoading: false,
+      isSaving: false,
+      error: null,
+      isInspecting: false,
+      inspectionError: new BookmarkApiError(
+        "The page did not expose usable metadata.",
+        422,
+      ),
+      addResource,
+      inspectResource,
+      dismissInspectionError,
+      resetInspection,
+      refresh: vi.fn(),
+    });
+    const user = userEvent.setup();
+    render(<LibraryPage />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Resource URL" }),
+      "https://example.com/resource",
+    );
+    await user.click(screen.getByRole("button", { name: "Inspect URL" }));
+
+    const inspectionAlert = await screen.findByRole("alert");
+    expect(inspectionAlert).toHaveTextContent(/couldn’t inspect this URL/i);
+    expect(inspectionAlert).toHaveTextContent(
+      "The page did not expose usable metadata.",
+    );
+    expect(screen.getByRole("button", { name: "Save Resource" })).toBeEnabled();
+
+    await user.type(
+      screen.getByRole("textbox", { name: /^tags/i }),
+      "research{Enter}",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Resource" }));
+
+    expect(addResource).toHaveBeenCalledWith({
+      url: "https://example.com/resource",
+      tags: ["research"],
+      notes: undefined,
+    });
+  });
+
+  it("blocks inspection client-side when the URL is invalid", async () => {
+    const user = userEvent.setup();
+    render(<LibraryPage />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Resource URL" }),
+      "not-a-url",
+    );
+    await user.click(screen.getByRole("button", { name: "Inspect URL" }));
+
+    expect(inspectResource).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("textbox", { name: "Resource URL" }),
+    ).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Please enter a valid URL")).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useLibraryResources.test.tsx
+++ b/src/hooks/__tests__/useLibraryResources.test.tsx
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api")>();
+  return {
+    ...actual,
+    getLibraryResources: vi.fn(),
+    inspectLibraryResource: vi.fn(),
+  };
+});
+
+import {
+  getLibraryResources,
+  inspectLibraryResource,
+  type LibraryInspection,
+} from "../../api";
+import { useLibraryResources } from "../useLibraryResources";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("useLibraryResources inspection cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getLibraryResources).mockResolvedValue({ resources: [] });
+  });
+
+  it("invalidates an in-flight inspection when the access token changes", async () => {
+    const pendingInspection = deferred<LibraryInspection>();
+    vi.mocked(inspectLibraryResource).mockReturnValue(
+      pendingInspection.promise,
+    );
+    const { result, rerender } = renderHook(
+      ({ accessToken }) => useLibraryResources(accessToken),
+      { initialProps: { accessToken: "first-token" } },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let inspectionPromise!: Promise<LibraryInspection | null>;
+    act(() => {
+      inspectionPromise = result.current.inspectResource(
+        "https://example.com/resource",
+      );
+    });
+    rerender({ accessToken: "second-token" });
+    pendingInspection.resolve({ title: "Stale", description: null });
+
+    await expect(inspectionPromise).resolves.toBeNull();
+  });
+
+  it("invalidates an in-flight inspection on unmount", async () => {
+    const pendingInspection = deferred<LibraryInspection>();
+    vi.mocked(inspectLibraryResource).mockReturnValue(
+      pendingInspection.promise,
+    );
+    const { result, unmount } = renderHook(() =>
+      useLibraryResources("verified-token"),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let inspectionPromise!: Promise<LibraryInspection | null>;
+    act(() => {
+      inspectionPromise = result.current.inspectResource(
+        "https://example.com/resource",
+      );
+    });
+    unmount();
+    pendingInspection.resolve({ title: "Stale", description: null });
+
+    await expect(inspectionPromise).resolves.toBeNull();
+  });
+});

--- a/src/hooks/useLibraryResources.ts
+++ b/src/hooks/useLibraryResources.ts
@@ -171,6 +171,7 @@ export function useLibraryResources(accessToken: string | null) {
 
     return () => {
       requestIdRef.current += 1;
+      inspectionRequestIdRef.current += 1;
     };
   }, [fetchResources]);
 

--- a/src/hooks/useLibraryResources.ts
+++ b/src/hooks/useLibraryResources.ts
@@ -4,6 +4,8 @@ import {
   addLibraryResource,
   BookmarkApiError,
   getLibraryResources,
+  inspectLibraryResource,
+  type LibraryInspection,
   type LibraryResource,
 } from "../api";
 import type { PersonalResourceRequest } from "../lib/validation";
@@ -15,14 +17,25 @@ interface UseLibraryResourcesState {
   error: BookmarkApiError | null;
 }
 
+interface LibraryInspectionState {
+  isInspecting: boolean;
+  inspectionError: BookmarkApiError | null;
+}
+
 export function useLibraryResources(accessToken: string | null) {
   const requestIdRef = useRef(0);
+  const inspectionRequestIdRef = useRef(0);
   const [state, setState] = useState<UseLibraryResourcesState>({
     resources: [],
     isLoading: false,
     isSaving: false,
     error: null,
   });
+  const [inspectionState, setInspectionState] =
+    useState<LibraryInspectionState>({
+      isInspecting: false,
+      inspectionError: null,
+    });
 
   const fetchResources = useCallback(async () => {
     requestIdRef.current += 1;
@@ -105,6 +118,52 @@ export function useLibraryResources(accessToken: string | null) {
     [accessToken],
   );
 
+  const inspectResource = useCallback(
+    async (url: string): Promise<LibraryInspection | null> => {
+      inspectionRequestIdRef.current += 1;
+      const inspectionRequestId = inspectionRequestIdRef.current;
+
+      if (!accessToken) {
+        setInspectionState({
+          isInspecting: false,
+          inspectionError: new BookmarkApiError("Authentication required", 401),
+        });
+        return null;
+      }
+
+      setInspectionState({ isInspecting: true, inspectionError: null });
+
+      try {
+        const metadata = await inspectLibraryResource(url, accessToken);
+        if (inspectionRequestId !== inspectionRequestIdRef.current) {
+          return null;
+        }
+        setInspectionState({ isInspecting: false, inspectionError: null });
+        return metadata;
+      } catch (error) {
+        if (inspectionRequestId !== inspectionRequestIdRef.current) {
+          return null;
+        }
+        const inspectionError =
+          error instanceof BookmarkApiError
+            ? error
+            : new BookmarkApiError("Failed to inspect this URL", 500);
+        setInspectionState({ isInspecting: false, inspectionError });
+        return null;
+      }
+    },
+    [accessToken],
+  );
+
+  const dismissInspectionError = useCallback(() => {
+    setInspectionState((previous) => ({ ...previous, inspectionError: null }));
+  }, []);
+
+  const resetInspection = useCallback(() => {
+    inspectionRequestIdRef.current += 1;
+    setInspectionState({ isInspecting: false, inspectionError: null });
+  }, []);
+
   useEffect(() => {
     // This effect synchronizes React state with the server-backed library.
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -117,7 +176,11 @@ export function useLibraryResources(accessToken: string | null) {
 
   return {
     ...state,
+    ...inspectionState,
     addResource,
+    inspectResource,
+    dismissInspectionError,
+    resetInspection,
     refresh: fetchResources,
   };
 }

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -113,6 +113,23 @@ describe("Validation Schemas", () => {
 
       expect(result.success).toBe(true);
     });
+
+    it("should reject oversized metadata overrides", () => {
+      expect(
+        validatePersonalResourceRequest({
+          url: "https://example.com/resource",
+          title: "t".repeat(301),
+          tags: ["react"],
+        }).success,
+      ).toBe(false);
+      expect(
+        validatePersonalResourceRequest({
+          url: "https://example.com/resource",
+          description: "d".repeat(2001),
+          tags: ["react"],
+        }).success,
+      ).toBe(false);
+    });
   });
 
   describe("validateLibraryInspectionRequest", () => {

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   validateToolSubmission,
+  validateLibraryInspectionRequest,
   validatePersonalResourceRequest,
   validatePublicSubmissionRequest,
   validatePublicSubmissionResponse,
@@ -101,6 +102,36 @@ describe("Validation Schemas", () => {
 
       expect(result.success).toBe(false);
     });
+
+    it("should accept optional metadata overrides", () => {
+      const result = validatePersonalResourceRequest({
+        url: "https://example.com/resource",
+        title: "Personal title",
+        description: "Personal description",
+        tags: ["react"],
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("validateLibraryInspectionRequest", () => {
+    it("should accept only an HTTP/HTTPS URL", () => {
+      expect(
+        validateLibraryInspectionRequest({
+          url: "https://example.com/resource",
+        }).success,
+      ).toBe(true);
+      expect(
+        validateLibraryInspectionRequest({ url: "file:///etc/passwd" }).success,
+      ).toBe(false);
+      expect(
+        validateLibraryInspectionRequest({
+          url: "https://example.com/resource",
+          userId: "user-1",
+        }).success,
+      ).toBe(false);
+    });
   });
 
   describe("validatePublicSubmissionRequest", () => {
@@ -183,7 +214,6 @@ describe("Validation Schemas", () => {
 
       expect(result.success).toBe(false);
     });
-
   });
 
   describe("validatePublicSubmissionResponse", () => {

--- a/src/lib/services/metadata.ts
+++ b/src/lib/services/metadata.ts
@@ -1,4 +1,5 @@
 import * as cheerio from "cheerio";
+import type { Dispatcher } from "undici";
 
 /**
  * Result of metadata extraction from a URL
@@ -10,7 +11,14 @@ export interface MetadataResult {
   error?: string;
 }
 
-function resolveMetadataUrl(candidateUrl: string | undefined, pageUrl: string): string | null {
+interface MetadataRequestOptions {
+  dispatcher?: Dispatcher;
+}
+
+function resolveMetadataUrl(
+  candidateUrl: string | undefined,
+  pageUrl: string,
+): string | null {
   if (!candidateUrl) {
     return null;
   }
@@ -27,14 +35,18 @@ function resolveMetadataUrl(candidateUrl: string | undefined, pageUrl: string): 
  * @param url - URL to fetch and extract metadata from
  * @returns Extracted metadata or null values with error on failure
  */
-export async function extractMetadata(url: string): Promise<MetadataResult> {
+export async function extractMetadata(
+  url: string,
+  options: MetadataRequestOptions = {},
+): Promise<MetadataResult> {
   try {
     const response = await fetch(url, {
       headers: {
         "User-Agent": "Makerbench/1.0 (Bookmark Metadata Extractor)",
       },
       signal: AbortSignal.timeout(15000), // 15s timeout
-    });
+      dispatcher: options.dispatcher,
+    } as RequestInit & { dispatcher?: Dispatcher });
 
     if (!response.ok) {
       return {
@@ -59,7 +71,10 @@ export async function extractMetadata(url: string): Promise<MetadataResult> {
     const description = ogDescription || metaDescription || null;
 
     // Extract OG image
-    const ogImage = resolveMetadataUrl($('meta[property="og:image"]').attr("content"), url);
+    const ogImage = resolveMetadataUrl(
+      $('meta[property="og:image"]').attr("content"),
+      url,
+    );
 
     return { title, description, ogImage };
   } catch (error) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -20,7 +20,10 @@ function isHttpUrl(value: string): boolean {
 const resourceUrlSchema = v.pipe(
   v.string(),
   v.minLength(1, "URL is required"),
-  v.maxLength(MAX_URL_LENGTH, `URL must be ${MAX_URL_LENGTH} characters or less`),
+  v.maxLength(
+    MAX_URL_LENGTH,
+    `URL must be ${MAX_URL_LENGTH} characters or less`,
+  ),
   v.url("Please enter a valid URL"),
   v.check(isHttpUrl, "Please enter a valid HTTP/HTTPS URL"),
 );
@@ -46,7 +49,9 @@ const githubProfileUrlSchema = v.pipe(
   ),
 );
 
-const optionalGithubProfileUrlSchema = v.optional(v.union([githubProfileUrlSchema, v.literal("")]));
+const optionalGithubProfileUrlSchema = v.optional(
+  v.union([githubProfileUrlSchema, v.literal("")]),
+);
 
 const optionalSubmitterNameSchema = v.optional(
   v.pipe(v.string(), v.maxLength(100, "Name must be 100 characters or less")),
@@ -67,7 +72,11 @@ const optionalGithubUsernameSchema = v.optional(
 );
 
 export const publicSubmissionTypeSchema = v.picklist(["tool", "resource"]);
-export const publicSubmissionStatusSchema = v.picklist(["pending", "approved", "rejected"]);
+export const publicSubmissionStatusSchema = v.picklist([
+  "pending",
+  "approved",
+  "rejected",
+]);
 
 export const publicSubmissionRequestSchema = v.strictObject({
   type: publicSubmissionTypeSchema,
@@ -136,8 +145,27 @@ export const bookmarkRequestSchema = v.object({
 
 export const personalResourceRequestSchema = v.object({
   url: resourceUrlSchema,
+  title: v.optional(v.string()),
+  description: v.optional(v.string()),
   tags: resourceTagsSchema,
-  notes: v.optional(v.pipe(v.string(), v.maxLength(5000, "Notes must be 5000 characters or less"))),
+  notes: v.optional(
+    v.pipe(
+      v.string(),
+      v.maxLength(5000, "Notes must be 5000 characters or less"),
+    ),
+  ),
+});
+
+export const libraryInspectionRequestSchema = v.strictObject({
+  url: resourceUrlSchema,
+});
+
+export const libraryInspectionResponseSchema = v.object({
+  success: v.literal(true),
+  data: v.object({
+    title: v.nullable(v.string()),
+    description: v.nullable(v.string()),
+  }),
 });
 
 export const toolMetadataSchema = v.object({
@@ -165,7 +193,9 @@ export const toolSchema = v.object({
 export const searchRequestSchema = v.object({
   query: v.optional(v.string()),
   tags: v.optional(v.array(v.string())),
-  limit: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100))),
+  limit: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100)),
+  ),
   offset: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
 });
 
@@ -185,11 +215,27 @@ export type Tag = v.InferOutput<typeof tagSchema>;
 export type Submitter = v.InferOutput<typeof submitterSchema>;
 export type ToolSubmissionData = v.InferOutput<typeof toolSubmissionSchema>;
 export type BookmarkRequest = v.InferOutput<typeof bookmarkRequestSchema>;
-export type PersonalResourceRequest = v.InferOutput<typeof personalResourceRequestSchema>;
-export type PublicSubmissionType = v.InferOutput<typeof publicSubmissionTypeSchema>;
-export type PublicSubmissionStatus = v.InferOutput<typeof publicSubmissionStatusSchema>;
-export type PublicSubmissionRequest = v.InferOutput<typeof publicSubmissionRequestSchema>;
-export type PublicSubmissionResponseData = v.InferOutput<typeof publicSubmissionResponseDataSchema>;
+export type PersonalResourceRequest = v.InferOutput<
+  typeof personalResourceRequestSchema
+>;
+export type LibraryInspectionRequest = v.InferOutput<
+  typeof libraryInspectionRequestSchema
+>;
+export type LibraryInspectionResponse = v.InferOutput<
+  typeof libraryInspectionResponseSchema
+>;
+export type PublicSubmissionType = v.InferOutput<
+  typeof publicSubmissionTypeSchema
+>;
+export type PublicSubmissionStatus = v.InferOutput<
+  typeof publicSubmissionStatusSchema
+>;
+export type PublicSubmissionRequest = v.InferOutput<
+  typeof publicSubmissionRequestSchema
+>;
+export type PublicSubmissionResponseData = v.InferOutput<
+  typeof publicSubmissionResponseDataSchema
+>;
 export type ApiErrorResponse = v.InferOutput<typeof apiErrorResponseSchema>;
 export type ToolMetadata = v.InferOutput<typeof toolMetadataSchema>;
 export type Tool = v.InferOutput<typeof toolSchema>;
@@ -207,6 +253,10 @@ export const validateBookmarkRequest = (data: unknown) => {
 
 export const validatePersonalResourceRequest = (data: unknown) => {
   return v.safeParse(personalResourceRequestSchema, data);
+};
+
+export const validateLibraryInspectionRequest = (data: unknown) => {
+  return v.safeParse(libraryInspectionRequestSchema, data);
 };
 
 export const validatePublicSubmissionRequest = (data: unknown) => {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -145,8 +145,18 @@ export const bookmarkRequestSchema = v.object({
 
 export const personalResourceRequestSchema = v.object({
   url: resourceUrlSchema,
-  title: v.optional(v.string()),
-  description: v.optional(v.string()),
+  title: v.optional(
+    v.pipe(
+      v.string(),
+      v.maxLength(300, "Title must be 300 characters or less"),
+    ),
+  ),
+  description: v.optional(
+    v.pipe(
+      v.string(),
+      v.maxLength(2000, "Description must be 2000 characters or less"),
+    ),
+  ),
   tags: resourceTagsSchema,
   notes: v.optional(
     v.pipe(

--- a/src/pages/LibraryPage.css
+++ b/src/pages/LibraryPage.css
@@ -45,17 +45,28 @@
   padding: 0;
 }
 
-.LibraryPage-notes {
+.LibraryPage-inspectionControls {
+  align-items: end;
+  display: grid;
+  gap: var(--size-12);
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.LibraryPage-inspectButton {
+  margin-block-end: var(--size-2);
+}
+
+.LibraryPage-textarea {
   display: grid;
   gap: var(--size-8);
 }
 
-.LibraryPage-notesLabel {
+.LibraryPage-textareaLabel {
   color: var(--color-text);
   font: var(--typography-label);
 }
 
-.LibraryPage-notesField {
+.LibraryPage-textareaField {
   background-color: var(--color-surface);
   border: var(--border-strong);
   border-radius: var(--radius-md);
@@ -66,9 +77,21 @@
   resize: vertical;
 }
 
-.LibraryPage-notesError {
+.LibraryPage-textareaError {
   color: var(--color-error);
   font: var(--typography-caption);
+}
+
+@media (width < 32rem) {
+  .LibraryPage-inspectionControls {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .LibraryPage-inspectButton {
+    justify-self: start;
+    margin-block-end: 0;
+  }
 }
 
 .LibraryPage-list {

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -7,28 +7,45 @@ import { Button } from "../components/ui/Button";
 import { TextInput } from "../components/ui/TextInput";
 import { useAuth } from "../hooks/useAuth";
 import { useLibraryResources } from "../hooks/useLibraryResources";
-import { personalResourceRequestSchema, type PersonalResourceRequest } from "../lib/validation";
+import {
+  libraryInspectionRequestSchema,
+  personalResourceRequestSchema,
+  type PersonalResourceRequest,
+} from "../lib/validation";
 
 import "./LibraryPage.css";
 
 interface FormErrors {
   url?: string;
+  title?: string;
+  description?: string;
   tags?: string;
   notes?: string;
 }
 
+interface InspectedMetadata {
+  url: string;
+  title: string | null;
+  description: string | null;
+}
+
 interface LibraryPageState {
   url: string;
+  title: string;
+  description: string;
   tags: string[];
   notes: string;
   formErrors: FormErrors;
   didSave: boolean;
   signInError: string | null;
   isSignInPending: boolean;
+  inspectedMetadata: InspectedMetadata | null;
 }
 
 type LibraryPageAction =
   | { type: "setUrl"; url: string }
+  | { type: "setTitle"; title: string }
+  | { type: "setDescription"; description: string }
   | { type: "setTags"; tags: string[] }
   | { type: "setNotes"; notes: string }
   | { type: "setFormErrors"; formErrors: FormErrors }
@@ -37,22 +54,39 @@ type LibraryPageAction =
   | { type: "finishSignIn" }
   | { type: "failSignIn"; message: string }
   | { type: "dismissSignInError" }
+  | { type: "finishInspection"; metadata: InspectedMetadata }
   | { type: "resetFormAfterSave" };
 
 const initialState: LibraryPageState = {
   url: "",
+  title: "",
+  description: "",
   tags: [],
   notes: "",
   formErrors: {},
   didSave: false,
   signInError: null,
   isSignInPending: false,
+  inspectedMetadata: null,
 };
 
-function libraryPageReducer(state: LibraryPageState, action: LibraryPageAction): LibraryPageState {
+function libraryPageReducer(
+  state: LibraryPageState,
+  action: LibraryPageAction,
+): LibraryPageState {
   switch (action.type) {
     case "setUrl":
-      return { ...state, url: action.url };
+      return {
+        ...state,
+        url: action.url,
+        title: "",
+        description: "",
+        inspectedMetadata: null,
+      };
+    case "setTitle":
+      return { ...state, title: action.title };
+    case "setDescription":
+      return { ...state, description: action.description };
     case "setTags":
       return { ...state, tags: action.tags };
     case "setNotes":
@@ -69,14 +103,28 @@ function libraryPageReducer(state: LibraryPageState, action: LibraryPageAction):
       return { ...state, signInError: action.message, isSignInPending: false };
     case "dismissSignInError":
       return { ...state, signInError: null };
+    case "finishInspection":
+      if (state.url.trim() !== action.metadata.url) {
+        return state;
+      }
+
+      return {
+        ...state,
+        title: action.metadata.title ?? "",
+        description: action.metadata.description ?? "",
+        inspectedMetadata: action.metadata,
+      };
     case "resetFormAfterSave":
       return {
         ...state,
         url: "",
+        title: "",
+        description: "",
         tags: [],
         notes: "",
         formErrors: {},
         didSave: true,
+        inspectedMetadata: null,
       };
   }
 }
@@ -100,6 +148,21 @@ function getFormErrors(data: PersonalResourceRequest): FormErrors {
   return errors;
 }
 
+function getInspectionUrlError(url: string): string | undefined {
+  const result = v.safeParse(libraryInspectionRequestSchema, { url });
+
+  if (result.success) {
+    return undefined;
+  }
+
+  const urlIssue = result.issues.find((issue) => {
+    const pathItem = issue.path?.[0] as { key?: unknown } | undefined;
+    return pathItem?.key === "url";
+  });
+
+  return urlIssue?.message;
+}
+
 export function LibraryPage() {
   const {
     accessToken,
@@ -108,9 +171,31 @@ export function LibraryPage() {
     signInWithGitHub,
     signInWithGoogle,
   } = useAuth();
-  const { resources, isLoading, isSaving, error, addResource } = useLibraryResources(accessToken);
+  const {
+    resources,
+    isLoading,
+    isSaving,
+    error,
+    addResource,
+    isInspecting,
+    inspectionError,
+    inspectResource,
+    dismissInspectionError,
+    resetInspection,
+  } = useLibraryResources(accessToken);
   const [state, dispatch] = useReducer(libraryPageReducer, initialState);
-  const { url, tags, notes, formErrors, didSave, signInError, isSignInPending } = state;
+  const {
+    url,
+    title,
+    description,
+    tags,
+    notes,
+    formErrors,
+    didSave,
+    signInError,
+    isSignInPending,
+    inspectedMetadata,
+  } = state;
 
   async function handleSignIn(action: () => Promise<void>) {
     dispatch({ type: "startSignIn" });
@@ -121,7 +206,10 @@ export function LibraryPage() {
     } catch (error) {
       dispatch({
         type: "failSignIn",
-        message: error instanceof Error ? error.message : "Sign in failed. Please try again.",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Sign in failed. Please try again.",
       });
     }
   }
@@ -130,10 +218,23 @@ export function LibraryPage() {
     event.preventDefault();
     dispatch({ type: "setDidSave", didSave: false });
 
+    const trimmedUrl = url.trim();
+    const trimmedTitle = title.trim();
+    const trimmedDescription = description.trim();
+    const inspectedTitle = inspectedMetadata?.title?.trim() ?? "";
+    const inspectedDescription = inspectedMetadata?.description?.trim() ?? "";
+    const shouldOverrideTitle = inspectedMetadata
+      ? trimmedTitle !== inspectedTitle
+      : trimmedTitle.length > 0;
+    const shouldOverrideDescription = inspectedMetadata
+      ? trimmedDescription !== inspectedDescription
+      : trimmedDescription.length > 0;
     const data: PersonalResourceRequest = {
-      url: url.trim(),
+      url: trimmedUrl,
       tags,
       notes: notes.trim() || undefined,
+      ...(shouldOverrideTitle ? { title: trimmedTitle } : {}),
+      ...(shouldOverrideDescription ? { description: trimmedDescription } : {}),
     };
     const errors = getFormErrors(data);
     dispatch({ type: "setFormErrors", formErrors: errors });
@@ -144,7 +245,29 @@ export function LibraryPage() {
 
     const saved = await addResource(data);
     if (saved) {
+      resetInspection();
       dispatch({ type: "resetFormAfterSave" });
+    }
+  }
+
+  async function handleInspect() {
+    const trimmedUrl = url.trim();
+    const urlError = getInspectionUrlError(trimmedUrl);
+    dispatch({
+      type: "setFormErrors",
+      formErrors: { ...formErrors, url: urlError },
+    });
+
+    if (urlError) {
+      return;
+    }
+
+    const metadata = await inspectResource(trimmedUrl);
+    if (metadata) {
+      dispatch({
+        type: "finishInspection",
+        metadata: { url: trimmedUrl, ...metadata },
+      });
     }
   }
 
@@ -220,41 +343,110 @@ export function LibraryPage() {
         </Alert>
       )}
 
+      {inspectionError && (
+        <Alert variant="error" dismissible onDismiss={dismissInspectionError}>
+          <strong>Couldn’t inspect this URL.</strong> {inspectionError.message}{" "}
+          You can still save it without inspecting.
+        </Alert>
+      )}
+
       <form className="LibraryPage-form" onSubmit={handleSubmit} noValidate>
         <fieldset className="LibraryPage-fieldset" disabled={isSaving}>
           <legend className="visually-hidden">Save a resource</legend>
+          <div className="LibraryPage-inspectionControls">
+            <TextInput
+              id="library-url"
+              label="Resource URL"
+              type="url"
+              value={url}
+              onChange={(event) => {
+                resetInspection();
+                dispatch({ type: "setUrl", url: event.target.value });
+              }}
+              placeholder="https://example.com/resource"
+              required
+              error={formErrors.url}
+            />
+            <Button
+              className="LibraryPage-inspectButton"
+              type="button"
+              variant="secondary"
+              isLoading={isInspecting}
+              onClick={() => void handleInspect()}
+            >
+              {isInspecting ? "Inspecting…" : "Inspect URL"}
+            </Button>
+          </div>
           <TextInput
-            id="library-url"
-            label="Resource URL"
-            type="url"
-            value={url}
-            onChange={(event) => dispatch({ type: "setUrl", url: event.target.value })}
-            placeholder="https://example.com/resource"
-            required
-            error={formErrors.url}
+            id="library-title"
+            label="Title"
+            value={title}
+            onChange={(event) =>
+              dispatch({ type: "setTitle", title: event.target.value })
+            }
+            hint="Inspect the URL to prefill this, then edit it if needed."
+            error={formErrors.title}
           />
+          <label className="LibraryPage-textarea" htmlFor="library-description">
+            <span className="LibraryPage-textareaLabel">Description</span>
+            <textarea
+              id="library-description"
+              className="LibraryPage-textareaField"
+              value={description}
+              onChange={(event) =>
+                dispatch({
+                  type: "setDescription",
+                  description: event.target.value,
+                })
+              }
+              rows={4}
+              aria-invalid={formErrors.description ? true : undefined}
+              aria-describedby={
+                formErrors.description ? "library-description-error" : undefined
+              }
+            />
+            {formErrors.description && (
+              <span
+                id="library-description-error"
+                className="LibraryPage-textareaError"
+                role="alert"
+              >
+                {formErrors.description}
+              </span>
+            )}
+          </label>
           <TagInput
             id="library-tags"
             label="Tags"
             tags={tags}
-            onTagsChange={(nextTags) => dispatch({ type: "setTags", tags: nextTags })}
+            onTagsChange={(nextTags) =>
+              dispatch({ type: "setTags", tags: nextTags })
+            }
             maxTags={10}
             required
             error={formErrors.tags}
           />
-          <label className="LibraryPage-notes" htmlFor="library-notes">
-            <span className="LibraryPage-notesLabel">Notes</span>
+          <label className="LibraryPage-textarea" htmlFor="library-notes">
+            <span className="LibraryPage-textareaLabel">Notes</span>
             <textarea
               id="library-notes"
-              className="LibraryPage-notesField"
+              className="LibraryPage-textareaField"
               value={notes}
-              onChange={(event) => dispatch({ type: "setNotes", notes: event.target.value })}
+              onChange={(event) =>
+                dispatch({ type: "setNotes", notes: event.target.value })
+              }
               rows={5}
               aria-invalid={formErrors.notes ? true : undefined}
-              aria-describedby={formErrors.notes ? "library-notes-error" : undefined}
+              aria-describedby={
+                formErrors.notes ? "library-notes-error" : undefined
+              }
             />
             {formErrors.notes && (
-              <span id="library-notes-error" className="LibraryPage-notesError" role="alert">
+              <span
+                id="library-notes-error"
+                className="LibraryPage-textareaError"
+                role="alert"
+              >
                 {formErrors.notes}
               </span>
             )}
@@ -265,8 +457,14 @@ export function LibraryPage() {
         </Button>
       </form>
 
-      <section className="LibraryPage-list" aria-labelledby="library-list-title">
-        <h2 id="library-list-title" className="LibraryPage-listTitle heading-lg">
+      <section
+        className="LibraryPage-list"
+        aria-labelledby="library-list-title"
+      >
+        <h2
+          id="library-list-title"
+          className="LibraryPage-listTitle heading-lg"
+        >
           Saved Resources
         </h2>
         {isLoading ? (
@@ -282,13 +480,20 @@ export function LibraryPage() {
                     <a href={resource.url}>{resource.title}</a>
                   </h3>
                   {resource.description && (
-                    <p className="LibraryPage-cardDescription body-sm">{resource.description}</p>
+                    <p className="LibraryPage-cardDescription body-sm">
+                      {resource.description}
+                    </p>
                   )}
                   {resource.notes && (
-                    <p className="LibraryPage-cardNotes body-sm">{resource.notes}</p>
+                    <p className="LibraryPage-cardNotes body-sm">
+                      {resource.notes}
+                    </p>
                   )}
                   {resource.tags.length > 0 && (
-                    <ul className="LibraryPage-tags reset-list" aria-label="Tags">
+                    <ul
+                      className="LibraryPage-tags reset-list"
+                      aria-label="Tags"
+                    >
                       {resource.tags.map((tag) => (
                         <li key={tag.id} className="LibraryPage-tag">
                           {tag.name}


### PR DESCRIPTION
## Summary
- Add a library inspection flow that prefetches resource metadata before saving
- Allow personal title and description overrides while preserving shared resource metadata
- Extend validation, API client, hook state, and tests for the new inspection and override behavior

## Testing
- Added unit coverage for metadata override persistence and validation schemas
- Updated library form behavior to handle inspection, prefilling, and save-time override normalization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added URL inspection in the Library page to prefill editable title/description and save them as personal overrides.
  * Added a server-side library inspection endpoint with separate inspection rate limiting.
  * Added SSRF-protected public URL resolution for inspection/metadata fetching.
* **Bug Fixes**
  * Prevented stale/out-of-order inspection results from overwriting newer requests.
  * Improved user-facing handling when metadata extraction or inspection fails.
* **Tests**
  * Expanded coverage for inspection, validation, override persistence, rate limiting, and SSRF security.
* **Documentation**
  * Documented new inspection rate-limit environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->