### PR TITLE
Surface safe submission diagnostic codes in responses and UI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,83 @@
+# Query Contracts and Observability
+
+Deliver issues [#57](https://github.com/schalkneethling/makerbench-next/issues/57),
+[#76](https://github.com/schalkneethling/makerbench-next/issues/76),
+[#106](https://github.com/schalkneethling/makerbench-next/issues/106), and
+[#107](https://github.com/schalkneethling/makerbench-next/issues/107) as one
+cohesive PR.
+
+## Outcome
+
+- Tool and resource list/search endpoints share strict pagination parsing.
+- Tool list/search responses return accurate totals without breaking load-more behavior.
+- API performance telemetry is intentional, consistent, structured, and low-noise.
+- AND/OR tool-search behavior has an explicit product decision; if implemented,
+  the API, URL state, UI, and tests agree on the contract.
+
+## Before editing
+
+- [ ] Verify every issue against the current code and record obsolete or already-delivered scope.
+- [ ] Inventory pagination parsing, count queries, response schemas, URL parameters,
+      and `[perf]` logging across tool and resource endpoints and clients.
+- [ ] Search for existing utilities before adding helpers; consolidate repeated logic
+      behind typed, well-tested utilities.
+- [ ] Confirm current endpoint defaults and maximum limits so consolidation does not
+      change behavior accidentally.
+
+## Shared pagination contract — #76
+
+- [ ] Add or reuse one server-side pagination utility.
+- [ ] Require strict decimal strings: positive `limit`, non-negative `offset`, and
+      no trailing characters such as `20abc`.
+- [ ] Preserve endpoint-specific defaults and maximum limits through explicit configuration.
+- [ ] Apply the utility to tool list/search/tags and resource list/search endpoints.
+- [ ] Add utility boundary tests and focused endpoint tests for valid, missing,
+      capped, malformed, negative, and trailing-garbage values.
+
+## Accurate tool totals — #106
+
+- [ ] Add approved-tool count queries to tool list and search endpoints.
+- [ ] Ensure search totals use the same title/tag predicates as the result query.
+- [ ] Return numeric `pagination.total` while preserving `limit`, `offset`, and `hasMore`.
+- [ ] Update shared/client Valibot schemas and types only where required.
+- [ ] Verify `ResultCount` renders “Showing X of Y tools”.
+- [ ] Cover empty, filtered, paginated, and load-more cases.
+
+## Search-mode decision — #107
+
+- [ ] Review current AND-only behavior and decide whether an AND/OR control materially
+      improves the product without making search harder to understand.
+- [ ] If deferred, document AND-only behavior and close #107 with the rationale.
+- [ ] If implemented, define a non-conflicting query parameter contract, default to
+      AND, synchronize it with URL state, and show the control only when both title
+      and tag filters are active.
+- [ ] If implemented, use the same predicate builder for result and total-count queries
+      and test both modes at API and UI boundaries.
+
+## Performance observability — #57
+
+- [ ] Review server `[perf]` logs with the final count-query and pagination behavior.
+- [ ] Remove migration-only and duplicate client/hook timing logs.
+- [ ] Keep only measurements that support production diagnosis.
+- [ ] Give retained events consistent names and fields without logging sensitive data.
+- [ ] Prefer one shared timing/logging utility when multiple endpoints retain the same behavior.
+- [ ] Add tests only for project-owned formatting/redaction logic, not `console` itself.
+
+## Documentation and validation
+
+- [ ] Update API/architecture documentation for totals, strict pagination, retained
+      telemetry, and the search-mode decision.
+- [ ] Run `pnpm test` and record any unrelated baseline failures separately.
+- [ ] Run `pnpm lint`, `pnpm lint:css`, `pnpm typecheck`, formatting checks, and
+      `git diff --check`.
+- [ ] Run the production build with safe placeholder environment values when local
+      Varlock/1Password values are unavailable.
+- [ ] Update Playwright ARIA snapshots only if the search controls or page structure change.
+- [ ] Confirm no Vitest, Playwright, Node, or development-server processes remain.
+
+## Out of scope
+
+- Changing resource-card layout or visual design.
+- Broad API-client or React-hook modernization tracked by #60 and #75.
+- Search-provider migration or Algolia integration.
+- Unrelated cleanup discovered while touching the endpoints; create focused follow-up issues.

--- a/netlify/functions/__tests__/public-submissions.test.ts
+++ b/netlify/functions/__tests__/public-submissions.test.ts
@@ -395,6 +395,9 @@ describe("public-submissions", () => {
         createMockContext(),
       );
       expect(missingResponse.status).toBe(503);
+      expect(missingResponse.headers.get("X-MakerBench-Error-Code")).toBe(
+        "submission-rate-limit-configuration-unavailable",
+      );
       await expect(missingResponse.json()).resolves.toEqual({
         success: false,
         error: "Service temporarily unavailable",
@@ -414,6 +417,9 @@ describe("public-submissions", () => {
         createMockContext(),
       );
       expect(invalidResponse.status).toBe(503);
+      expect(invalidResponse.headers.get("X-MakerBench-Error-Code")).toBe(
+        "submission-rate-limit-configuration-unavailable",
+      );
       await expect(invalidResponse.json()).resolves.toEqual({
         success: false,
         error: "Service temporarily unavailable",
@@ -508,6 +514,9 @@ describe("public-submissions", () => {
       );
 
       expect(res.status).toBe(503);
+      expect(res.headers.get("X-MakerBench-Error-Code")).toBe(
+        "submission-blocklist-store-unavailable",
+      );
       await expect(res.json()).resolves.toEqual({
         success: false,
         error: "Service temporarily unavailable",
@@ -778,6 +787,9 @@ describe("public-submissions", () => {
     );
 
     expect(res.status).toBe(503);
+    expect(res.headers.get("X-MakerBench-Error-Code")).toBe(
+      "submission-rate-limit-store-unavailable",
+    );
     await expect(res.json()).resolves.toEqual({
       success: false,
       error: "Service temporarily unavailable",

--- a/netlify/functions/lib/env.ts
+++ b/netlify/functions/lib/env.ts
@@ -78,6 +78,7 @@ export function getServiceUnavailableMessage(): string {
 export async function handleMissingEnvironmentError(
   error: unknown,
   functionName: string,
+  diagnosticCode = "service-configuration-unavailable",
 ): Promise<Response> {
   if (!isMissingEnvironmentError(error)) {
     throw error;
@@ -88,13 +89,14 @@ export async function handleMissingEnvironmentError(
     missingKeys: error.missingKeys,
   });
   await flushSentry();
-  return serviceUnavailable(getServiceUnavailableMessage());
+  return serviceUnavailable(getServiceUnavailableMessage(), diagnosticCode);
 }
 
 /** Maps invalid environment values to the same safe client response as missing values. */
 export async function handleInvalidEnvironmentError(
   error: unknown,
   functionName: string,
+  diagnosticCode = "service-configuration-unavailable",
 ): Promise<Response> {
   if (!isInvalidEnvironmentError(error)) {
     throw error;
@@ -105,5 +107,5 @@ export async function handleInvalidEnvironmentError(
     invalidKeys: error.invalidKeys,
   });
   await flushSentry();
-  return serviceUnavailable(getServiceUnavailableMessage());
+  return serviceUnavailable(getServiceUnavailableMessage(), diagnosticCode);
 }

--- a/netlify/functions/lib/responses.ts
+++ b/netlify/functions/lib/responses.ts
@@ -18,12 +18,17 @@ export type ApiResponse<T> = SuccessResponse<T> | ErrorResponse;
 /**
  * Creates a JSON response with proper headers
  */
-function jsonResponse<T>(body: ApiResponse<T>, status: number): Response {
+function jsonResponse<T>(
+  body: ApiResponse<T>,
+  status: number,
+  additionalHeaders: Record<string, string> = {},
+): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: {
       "Content-Type": "application/json",
       "X-Content-Type-Options": "nosniff",
+      ...additionalHeaders,
     },
   });
 }
@@ -105,13 +110,17 @@ export function serverError(error: string): Response {
 /**
  * Service unavailable error (503)
  */
-export function serviceUnavailable(error: string): Response {
-  return jsonResponse({ success: false, error }, 503);
+export function serviceUnavailable(error: string, diagnosticCode?: string): Response {
+  return jsonResponse(
+    { success: false, error },
+    503,
+    diagnosticCode ? { "X-MakerBench-Error-Code": diagnosticCode } : undefined,
+  );
 }
 
 /** Generic dependency failure response with no internal implementation details. */
-export function dependencyUnavailable(): Response {
-  return serviceUnavailable("Service temporarily unavailable");
+export function dependencyUnavailable(diagnosticCode?: string): Response {
+  return serviceUnavailable("Service temporarily unavailable", diagnosticCode);
 }
 
 /**

--- a/netlify/functions/lib/submissions.ts
+++ b/netlify/functions/lib/submissions.ts
@@ -109,7 +109,11 @@ async function getOptionalAuthenticatedUser(
   try {
     assertRequiredEnv(["VITE_SUPABASE_URL", "VITE_SUPABASE_ANON_KEY"]);
   } catch (error) {
-    return handleMissingEnvironmentError(error, endpointName);
+    return handleMissingEnvironmentError(
+      error,
+      endpointName,
+      "submission-auth-configuration-unavailable",
+    );
   }
 
   const authenticated = await verifyAuthenticatedUser(req);
@@ -414,7 +418,11 @@ export async function handlePublicSubmission(
   try {
     assertRequiredEnv(["SUPABASE_DATABASE_URL"]);
   } catch (error) {
-    return handleMissingEnvironmentError(error, options.endpointName);
+    return handleMissingEnvironmentError(
+      error,
+      options.endpointName,
+      "submission-database-configuration-unavailable",
+    );
   }
 
   const authenticated = await getOptionalAuthenticatedUser(
@@ -459,7 +467,11 @@ export async function handlePublicSubmission(
       rateLimitConfig.secret,
     );
   } catch (error) {
-    return handleInvalidEnvironmentError(error, options.endpointName);
+    return handleInvalidEnvironmentError(
+      error,
+      options.endpointName,
+      "submission-rate-limit-configuration-unavailable",
+    );
   }
 
   try {
@@ -477,7 +489,7 @@ export async function handlePublicSubmission(
       },
     );
     await flushSentry();
-    return dependencyUnavailable();
+    return dependencyUnavailable("submission-rate-limit-store-unavailable");
   }
 
   const normalizedUrl = parseAndNormalizeUrl(validation.output.url);
@@ -503,7 +515,7 @@ export async function handlePublicSubmission(
       dependency: "submission-blocklist-store",
     });
     await flushSentry();
-    return dependencyUnavailable();
+    return dependencyUnavailable("submission-blocklist-store-unavailable");
   }
 
   try {
@@ -517,7 +529,7 @@ export async function handlePublicSubmission(
       dependency: "submission-store",
     });
     await flushSentry();
-    return dependencyUnavailable();
+    return dependencyUnavailable("submission-store-unavailable");
   }
 
   const tags = normalizeTags(validation.output.tags);

--- a/src/api/__tests__/submissions.test.ts
+++ b/src/api/__tests__/submissions.test.ts
@@ -124,6 +124,35 @@ describe("submitPublicSubmission", () => {
     });
   });
 
+  it("preserves safe diagnostic codes from unavailable submission responses", async () => {
+    server.use(
+      http.post(`${API_BASE}/api/submissions`, () =>
+        HttpResponse.json(
+          { success: false, error: "Service temporarily unavailable" },
+          {
+            status: 503,
+            headers: {
+              "X-MakerBench-Error-Code": "submission-rate-limit-store-unavailable",
+            },
+          },
+        ),
+      ),
+    );
+
+    await expect(
+      submitPublicSubmission({
+        type: "resource",
+        url: "https://example.com/reference",
+        tags: ["testing"],
+      }),
+    ).rejects.toMatchObject({
+      name: "PublicSubmissionApiError",
+      status: 503,
+      message: "Service temporarily unavailable",
+      code: "submission-rate-limit-store-unavailable",
+    });
+  });
+
   it("rejects malformed success payloads with a typed error", async () => {
     server.use(
       http.post(`${API_BASE}/api/submissions`, () =>

--- a/src/api/submissions.ts
+++ b/src/api/submissions.ts
@@ -26,25 +26,29 @@ export type PublicSubmissionResponse = PublicSubmissionResponseData;
 export class PublicSubmissionApiError extends Error {
   status: number;
   details?: Record<string, string[]>;
+  code?: string;
 
   constructor(
     message: string,
     status: number,
     details?: Record<string, string[]>,
+    code?: string,
   ) {
     super(message);
     this.name = "PublicSubmissionApiError";
     this.status = status;
     this.details = details;
+    this.code = code;
   }
 }
 
-function throwApiError(json: unknown, status: number): never {
+function throwApiError(json: unknown, response: Response): never {
   const parsed = v.safeParse(apiErrorResponseSchema, json);
   throw new PublicSubmissionApiError(
     parsed.success ? parsed.output.error : "An unexpected error occurred",
-    status,
+    response.status,
     parsed.success ? parsed.output.details : undefined,
+    response.headers.get("X-MakerBench-Error-Code") ?? undefined,
   );
 }
 
@@ -82,7 +86,7 @@ export async function submitPublicSubmission(
   const json = await parseJsonResponse(response);
 
   if (!response.ok) {
-    throwApiError(json, response.status);
+    throwApiError(json, response);
   }
 
   const result = v.safeParse(publicSubmissionResponseSchema, json);

--- a/src/components/__tests__/SubmitPage.test.tsx
+++ b/src/components/__tests__/SubmitPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SubmitPage } from "../../pages/SubmitPage";
 import { server } from "../../test/mocks/server";
@@ -27,6 +27,10 @@ const authDefaults = {
 
 beforeEach(() => {
   vi.mocked(useAuth).mockReturnValue(authDefaults);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("SubmitPage", () => {
@@ -239,7 +243,8 @@ describe("SubmitPage", () => {
     expect(screen.getByText(/url: this domain is blocked/i)).toBeInTheDocument();
   });
 
-  it("shows safe submission diagnostics to admins", async () => {
+  it("shows safe submission diagnostics to admins outside development mode", async () => {
+    vi.stubEnv("DEV", false);
     vi.mocked(useAuth).mockReturnValue({
       ...authDefaults,
       identity: {
@@ -282,5 +287,51 @@ describe("SubmitPage", () => {
     expect(
       screen.getByText("submission-rate-limit-configuration-unavailable"),
     ).toBeInTheDocument();
+  });
+
+  it("hides safe submission diagnostics from non-admins outside development mode", async () => {
+    vi.stubEnv("DEV", false);
+    vi.mocked(useAuth).mockReturnValue({
+      ...authDefaults,
+      identity: {
+        user: {
+          id: "user-1",
+          email: "ada@example.com",
+          displayName: "Ada Lovelace",
+          githubUsername: "ada-lovelace",
+          avatarUrl: null,
+        },
+        isAdmin: false,
+      },
+      accessToken: "verified-token",
+      isAdmin: false,
+      isAuthenticated: true,
+    });
+    server.use(
+      http.post("/api/submissions", () =>
+        HttpResponse.json(
+          { success: false, error: "Service temporarily unavailable" },
+          {
+            status: 503,
+            headers: {
+              "X-MakerBench-Error-Code": "submission-rate-limit-configuration-unavailable",
+            },
+          },
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+    render(<SubmitPage />);
+
+    await user.click(screen.getByRole("radio", { name: "Resource" }));
+    await user.type(screen.getByRole("textbox", { name: "URL" }), "https://example.com/guide");
+    await user.type(screen.getByRole("textbox", { name: /^tags/i }), "testing{Enter}");
+    await user.click(screen.getByRole("button", { name: "Submit Resource" }));
+
+    expect(await screen.findByText(/submission failed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/diagnostic code/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("submission-rate-limit-configuration-unavailable"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/SubmitPage.test.tsx
+++ b/src/components/__tests__/SubmitPage.test.tsx
@@ -238,4 +238,49 @@ describe("SubmitPage", () => {
     expect(await screen.findByText(/submission failed/i)).toBeInTheDocument();
     expect(screen.getByText(/url: this domain is blocked/i)).toBeInTheDocument();
   });
+
+  it("shows safe submission diagnostics to admins", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      ...authDefaults,
+      identity: {
+        user: {
+          id: "user-1",
+          email: "ada@example.com",
+          displayName: "Ada Lovelace",
+          githubUsername: "ada-lovelace",
+          avatarUrl: null,
+        },
+        isAdmin: true,
+      },
+      accessToken: "verified-token",
+      isAdmin: true,
+      isAuthenticated: true,
+    });
+    server.use(
+      http.post("/api/submissions", () =>
+        HttpResponse.json(
+          { success: false, error: "Service temporarily unavailable" },
+          {
+            status: 503,
+            headers: {
+              "X-MakerBench-Error-Code": "submission-rate-limit-configuration-unavailable",
+            },
+          },
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+    render(<SubmitPage />);
+
+    await user.click(screen.getByRole("radio", { name: "Resource" }));
+    await user.type(screen.getByRole("textbox", { name: "URL" }), "https://example.com/guide");
+    await user.type(screen.getByRole("textbox", { name: /^tags/i }), "testing{Enter}");
+    await user.click(screen.getByRole("button", { name: "Submit Resource" }));
+
+    expect(await screen.findByText(/submission failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/diagnostic code/i)).toBeInTheDocument();
+    expect(
+      screen.getByText("submission-rate-limit-configuration-unavailable"),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/pages/SubmitPage.css
+++ b/src/pages/SubmitPage.css
@@ -127,6 +127,11 @@
   padding-inline-start: var(--size-20);
 }
 
+.SubmitPage-errorDiagnostic {
+  color: var(--color-text-muted);
+  margin-block: var(--size-8) 0;
+}
+
 @media (width < 30rem) {
   .SubmitPage-typeOptions {
     grid-template-columns: minmax(0, 1fr);

--- a/src/pages/SubmitPage.tsx
+++ b/src/pages/SubmitPage.tsx
@@ -76,7 +76,13 @@ function getFormErrors(issues: readonly v.BaseIssue<unknown>[]): FormErrors {
 
 /** Public tool and resource submission form. */
 export function SubmitPage() {
-  const { identity, accessToken, isAuthenticated, isLoading: isAuthLoading } = useAuth();
+  const {
+    identity,
+    accessToken,
+    isAdmin,
+    isAuthenticated,
+    isLoading: isAuthLoading,
+  } = useAuth();
   const { submit, isSubmitting, error, response, reset } = usePublicSubmission({
     accessToken: accessToken ?? undefined,
   });
@@ -85,6 +91,7 @@ export function SubmitPage() {
   const requireName = !hasVerifiedName;
   const requireGithubUsername = !hasVerifiedGithubUsername;
   const isFormDisabled = isAuthLoading || isSubmitting;
+  const canSeeDiagnostics = isAdmin || import.meta.env.DEV;
 
   const [submissionType, setSubmissionType] = useState<PublicSubmissionType | "">("");
   const [url, setUrl] = useState("");
@@ -169,6 +176,11 @@ export function SubmitPage() {
                 </li>
               ))}
             </ul>
+          ) : null}
+          {canSeeDiagnostics && error.code ? (
+            <p className="SubmitPage-errorDiagnostic body-sm">
+              Diagnostic code: <code>{error.code}</code>
+            </p>
           ) : null}
         </Alert>
       ) : null}


### PR DESCRIPTION
## Summary
- Add `X-MakerBench-Error-Code` headers to safe 503 submission responses so clients can distinguish unavailable dependencies and configuration failures.
- Preserve those diagnostic codes in the public submission API error type and expose them to admins in the submit form.
- Extend tests to cover server responses, API error propagation, and admin-facing diagnostic rendering.

## Testing
- Added unit coverage for Netlify submission handlers and the public submission API client.
- Added UI test coverage for admin-only diagnostic display on the submit page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved public submission error handling with clearer messages for configuration, rate-limit, and service availability issues.
  - Submission failures now retain diagnostic details for more accurate troubleshooting.
  - Prevented sensitive diagnostics from being shown to standard users.

- **Improvements**
  - Administrators and development users can view additional submission diagnostic codes when errors occur.
  - Added coverage to validate error responses and diagnostic display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->